### PR TITLE
Fix incomplete results for large collections (>2500 items)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -198,3 +198,6 @@ coverage/
 # Development artifacts
 dist/
 .wrangler/
+
+# Git worktrees
+.worktrees/

--- a/docs/superpowers/specs/2026-03-15-large-collection-indexing-design.md
+++ b/docs/superpowers/specs/2026-03-15-large-collection-indexing-design.md
@@ -1,0 +1,57 @@
+# Large Collection Indexing Fix
+
+**Date:** 2026-03-15
+**Status:** Approved
+
+## Problem
+
+For users with large Discogs collections (4,000+ items), both `search_collection` and `get_collection_stats` return incomplete results. `get_collection_stats` reports 2,500 total releases when the actual collection has over 4,000 items. Searches miss known matches entirely.
+
+Three bugs compound to cause this:
+
+1. `getCompleteCollection` has `maxPages = 25`, capping indexing at 2,500 items (25 pages × 100 items/page).
+2. The returned `pagination.items` is set to `allReleases.length` (the truncated count), not the real Discogs total — so tools report the wrong number.
+3. The truncation detection logic is broken: `totalPages` has already been clamped to `Math.min(actualPages, maxPages)`, so `Math.ceil(allReleases.length / 100)` equals `totalPages`, making the condition always false. No warning is ever logged or shown.
+
+## Scope
+
+Support collections up to 5,000 items within existing Cloudflare Workers infrastructure (no new bindings, no Durable Objects). Collections larger than 5,000 items will still be truncated, but users will see an accurate count and a clear warning.
+
+## Design
+
+### Change 1 — `src/clients/cachedDiscogs.ts`: `getCompleteCollection`
+
+- Change `maxPages` default from `25` to `50` (covers 5,000 items at 100/page).
+- On the first page fetch, capture `actualTotalItems = pageResult.pagination.items` into a dedicated variable — Discogs always returns the real collection total in every page's pagination object. This variable must never be overwritten in subsequent iterations.
+- Replace the broken truncation check with `actualTotalItems > allReleases.length`. `actualTotalItems` (from `pagination.items`) is the authoritative Discogs count; it is the only correct basis for this check.
+- Change the returned `pagination.items` from `allReleases.length` to `actualTotalItems`, so callers always have access to the real Discogs total even when the indexed set is smaller. Note: the returned `pagination.pages` will remain the clamped value (e.g., 50) representing pages actually fetched — not the real Discogs page count. This is intentional: `pages` describes what was indexed; `items` describes the real collection. Tool-layer truncation checks must use `pagination.items`, not `pagination.pages`.
+- Also fix the `collections` KV cache TTL: `SmartCache` currently writes `collections` entries with a 30-minute KV TTL (from `DEFAULT_CACHE_CONFIG`), but `getCompleteCollection` passes `maxAge: 45 * 60` expecting a 45-minute window. Because the KV entry expires before `maxAge` is ever checked, the effective cache window is 30 minutes, not 45. Extend `DEFAULT_CACHE_CONFIG.collections` TTL to 45 minutes (`45 * 60`) to align with the intended behaviour. Once this is done, the `{ maxAge: 45 * 60 }` override at the `getCompleteCollection` call site is redundant and should be removed.
+- Update the cache key (naturally changes from `username:complete:25` to `username:complete:50`), bypassing any stale 25-page cached entries.
+- Update comments to reflect the new limit.
+
+**Performance note:** Cold-cache load for a 5,000-item collection makes 50 sequential API calls at ~1,100ms each ≈ 55 seconds of wall time. This is acceptable because the Cloudflare Workers 30s limit applies to CPU time, not wall-clock I/O wait; and this cost is paid once per 45-minute cache window.
+
+Each inner `searchCollection` call has its own per-page cache entry (TTL: 20 minutes). Pages previously fetched (e.g., pages 1–25 from the old 25-page index) may be served from warm cache; pages beyond the old limit (26–50) will always hit the Discogs API on first access. In practice this means a user upgrading from the old limit may see a faster-than-worst-case cold load.
+
+### Change 2 — `src/mcp/tools/authenticated.ts`: `get_collection_stats`
+
+- Switch from `getCompleteCollectionReleases()` to `getCompleteCollection()` to get both the releases array and the real total count.
+- When `pagination.items > releases.length`, change the "Total Releases" line to: `"X indexed of Y total"`.
+- Append a footer note: `"⚠️ Only X of your Y releases have been indexed. Stats above reflect the indexed portion only."`
+
+### Change 3 — `src/mcp/tools/authenticated.ts`: `search_collection`
+
+- Switch from `getCompleteCollectionReleases()` to `getCompleteCollection()` for the same reason.
+- When `pagination.items > releases.length`, append to the result: `"⚠️ Your collection has Y releases but only X were indexed. Some results may be missing."`
+
+### No changes to
+
+- `get_recommendations` — uses `getCompleteCollectionReleases()`, which wraps `getCompleteCollection()` and automatically benefits from the higher `maxPages` default without a call-site change.
+- Resource files — same reasoning.
+- The throttle mechanism or KV bindings.
+
+## Success Criteria
+
+- A user with 4,000 releases sees all 4,000 results from `search_collection` and correct stats from `get_collection_stats`.
+- A user with 6,500 releases sees 5,000 indexed results with a clear warning that their collection is larger than what's indexed.
+- No regressions for users with collections under 2,500 items.

--- a/src/clients/cachedDiscogs.ts
+++ b/src/clients/cachedDiscogs.ts
@@ -189,9 +189,6 @@ export class CachedDiscogsClient {
 	}
 
 	/**
-	 * Batch collection fetching with intelligent pagination
-	 */
-	/**
 	 * Fetch the complete collection with intelligent pagination and caching.
 	 *
 	 * This is the primary method tools should use when they need access to the
@@ -200,6 +197,7 @@ export class CachedDiscogsClient {
 	 * subsequent calls return instantly from cache.
 	 *
 	 * For a 1000-item collection this costs ~11 API calls on cold cache, 0 on warm.
+	 * For a 5000-item collection this costs ~50 API calls on cold cache (~55s at Discogs rate limits).
 	 */
 	async getCompleteCollection(
 		username: string,
@@ -207,7 +205,7 @@ export class CachedDiscogsClient {
 		accessTokenSecret: string,
 		consumerKey: string,
 		consumerSecret: string,
-		maxPages: number = 25, // Supports up to 2500 items at 100/page
+		maxPages: number = 50, // Supports up to 5000 items at 100/page
 	): Promise<DiscogsCollectionResponse> {
 		const cacheKey = `${username}:complete:${maxPages}`
 
@@ -217,10 +215,10 @@ export class CachedDiscogsClient {
 			async () => {
 				console.log(`Fetching complete collection for ${username} (max ${maxPages} pages)`)
 
-				// Start with first page
 				let allReleases: DiscogsCollectionItem[] = []
 				let currentPage = 1
 				let totalPages = 1
+				let actualTotalItems = 0
 
 				do {
 					const pageResult = await this.searchCollection(
@@ -232,29 +230,38 @@ export class CachedDiscogsClient {
 						consumerSecret,
 					)
 
+					// Capture the real Discogs total from the first page only.
+					// Never overwrite — pagination.items is stable across all pages.
+					if (currentPage === 1) {
+						actualTotalItems = pageResult.pagination.items
+					}
+
 					allReleases = allReleases.concat(pageResult.releases)
 					totalPages = Math.min(pageResult.pagination.pages, maxPages)
 					currentPage++
 				} while (currentPage <= totalPages)
 
-				const wasTruncated = totalPages < (allReleases.length > 0 ? Math.ceil(allReleases.length / 100) : 1)
-				if (wasTruncated) {
-					console.log(`Collection truncated at ${maxPages} pages (${allReleases.length} items). Actual collection may be larger.`)
+				const isTruncated = actualTotalItems > allReleases.length
+				if (isTruncated) {
+					console.log(
+						`Collection truncated: indexed ${allReleases.length} of ${actualTotalItems} items (hit ${maxPages}-page limit).`,
+					)
 				}
 
-				// Return in the same format as regular collection response
+				// pagination.pages = pages actually fetched (clamped to maxPages).
+				// pagination.items = REAL Discogs total, even when truncated.
+				// Tool-layer truncation checks must use pagination.items, not pagination.pages.
 				return {
 					pagination: {
 						pages: totalPages,
 						page: 1,
 						per_page: allReleases.length,
-						items: allReleases.length,
+						items: actualTotalItems || allReleases.length,
 						urls: {},
 					},
 					releases: allReleases,
 				}
 			},
-			{ maxAge: 45 * 60 }, // Cache complete collections for 45 minutes
 		)
 	}
 

--- a/src/mcp/tools/authenticated.ts
+++ b/src/mcp/tools/authenticated.ts
@@ -408,22 +408,31 @@ export function registerAuthenticatedTools(server: McpServer, env: Env, getSessi
 				const allResults: DiscogsCollectionItem[] = []
 				const seenReleaseIds = new Set<string>()
 				let allReleases: DiscogsCollectionItem[] = []
+				let collectionTruncationNote = ''
 
 				if (cachedClient) {
 					// Fetch complete collection once (cached for 45 min)
-					allReleases = await cachedClient.getCompleteCollectionReleases(
+					const collection = await cachedClient.getCompleteCollection(
 						userProfile.username,
 						session.accessToken,
 						session.accessTokenSecret,
 						env.DISCOGS_CONSUMER_KEY,
 						env.DISCOGS_CONSUMER_SECRET,
 					)
+					allReleases = collection.releases
+					if (collection.pagination.items > collection.releases.length) {
+						collectionTruncationNote = `\n\n⚠️ Your collection has ${collection.pagination.items} releases but only ${collection.releases.length} were indexed. Some results may be missing.`
+					}
 
 					// Semantic query detection: if the query is conceptual/descriptive
 					// (not matching artists, albums, genres, or moods), short-circuit
 					// and return the full collection for LLM-based selection.
 					if (isSemanticQuery(query, allReleases)) {
-						return formatCollectionForSemanticSearch(allReleases, query)
+						const semanticResult = formatCollectionForSemanticSearch(allReleases, query)
+						if (collectionTruncationNote && semanticResult.content?.[0]?.type === 'text') {
+							semanticResult.content[0].text += collectionTruncationNote
+						}
+						return semanticResult
 					}
 
 					// Run each query variant as an in-memory filter against the same dataset
@@ -506,7 +515,7 @@ export function registerAuthenticatedTools(server: McpServer, env: Env, getSessi
 					content: [
 						{
 							type: 'text',
-							text: `${summary}${temporalInfo}${moodInfo}\n${releaseList}\n\n**Tip:** Use the release IDs with the get_release tool for detailed information about specific albums.`,
+							text: `${summary}${temporalInfo}${moodInfo}\n${releaseList}\n\n**Tip:** Use the release IDs with the get_release tool for detailed information about specific albums.${collectionTruncationNote}`,
 						},
 					],
 				}

--- a/src/mcp/tools/authenticated.ts
+++ b/src/mcp/tools/authenticated.ts
@@ -620,15 +620,19 @@ export function registerAuthenticatedTools(server: McpServer, env: Env, getSessi
 				// This reuses the same cached dataset as search_collection and
 				// get_recommendations, so if either was called first, this is free.
 				let stats
+				let collectionTotalItems = 0
+				let collectionIndexedItems = 0
 				if (cachedClient) {
-					const allReleases = await cachedClient.getCompleteCollectionReleases(
+					const collection = await cachedClient.getCompleteCollection(
 						userProfile.username,
 						session.accessToken,
 						session.accessTokenSecret,
 						env.DISCOGS_CONSUMER_KEY,
 						env.DISCOGS_CONSUMER_SECRET,
 					)
-					stats = cachedClient.computeStatsFromReleases(allReleases)
+					stats = cachedClient.computeStatsFromReleases(collection.releases)
+					collectionTotalItems = collection.pagination.items
+					collectionIndexedItems = collection.releases.length
 				} else {
 					stats = await client.getCollectionStats(
 						userProfile.username,
@@ -637,10 +641,18 @@ export function registerAuthenticatedTools(server: McpServer, env: Env, getSessi
 						env.DISCOGS_CONSUMER_KEY,
 						env.DISCOGS_CONSUMER_SECRET,
 					)
+					collectionTotalItems = stats.totalReleases
+					collectionIndexedItems = stats.totalReleases
 				}
 
+				const isIncomplete = collectionTotalItems > collectionIndexedItems
+
 				let text = `**Collection Statistics for ${userProfile.username}**\n\n`
-				text += `Total Releases: ${stats.totalReleases}\n`
+				if (isIncomplete) {
+					text += `Total Releases: ${collectionIndexedItems} indexed of ${collectionTotalItems} total\n`
+				} else {
+					text += `Total Releases: ${stats.totalReleases}\n`
+				}
 				text += `Average Rating: ${stats.averageRating.toFixed(1)} (${stats.ratedReleases} rated releases)\n\n`
 
 				text += `**Top Genres:**\n`
@@ -666,6 +678,10 @@ export function registerAuthenticatedTools(server: McpServer, env: Env, getSessi
 				topFormats.forEach(([format, count]) => {
 					text += `• ${format}: ${count} releases\n`
 				})
+
+				if (isIncomplete) {
+					text += `\n⚠️ Only ${collectionIndexedItems} of your ${collectionTotalItems} releases have been indexed. Stats above reflect the indexed portion only.`
+				}
 
 				return {
 					content: [

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -299,7 +299,7 @@ export const CacheKeys = {
 export function createDiscogsCache(kv: KVNamespace): SmartCache {
 	return new SmartCache(kv, {
 		// Tune cache TTLs based on data freshness requirements
-		collections: 30 * 60, // Collections don't change often
+		collections: 45 * 60, // Complete collection cache; aligns with getCompleteCollection's 45-min intent
 		releases: 24 * 60 * 60, // Release data is mostly static
 		stats: 60 * 60, // Stats can be cached for an hour
 		searches: 15 * 60, // Search results cached for 15 minutes

--- a/test/clients/cachedDiscogs.test.ts
+++ b/test/clients/cachedDiscogs.test.ts
@@ -1,0 +1,96 @@
+// test/clients/cachedDiscogs.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { CachedDiscogsClient } from '../../src/clients/cachedDiscogs'
+import { DiscogsClient } from '../../src/clients/discogs'
+
+// Minimal KV mock — only methods actually used by SmartCache
+function makeKV(store: Map<string, string> = new Map()): KVNamespace {
+  return {
+    get: vi.fn(async (key: string) => store.get(key) ?? null),
+    put: vi.fn(async (key: string, value: string) => { store.set(key, value) }),
+    delete: vi.fn(async (key: string) => { store.delete(key) }),
+    list: vi.fn(async () => ({ keys: [], list_complete: true, cursor: '' })),
+  } as unknown as KVNamespace
+}
+
+function makePageResponse(page: number, totalPages: number, totalItems: number) {
+  const isLastPage = page === totalPages
+  const itemsInLastPage = totalItems % 100 || 100
+  const releasesCount = isLastPage ? itemsInLastPage : 100
+  const releases = Array.from({ length: releasesCount }, (_, i) => ({ id: page * 100 + i }))
+  return {
+    pagination: { page, pages: totalPages, per_page: 100, items: totalItems, urls: {} },
+    releases,
+  }
+}
+
+describe('CachedDiscogsClient.getCompleteCollection', () => {
+  let client: CachedDiscogsClient
+  let mockSearchCollection: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    const kv = makeKV()
+    // CachedDiscogsClient constructor: (client: DiscogsClient, kv: KVNamespace)
+    // The inner DiscogsClient is irrelevant here — we spy on searchCollection directly.
+    client = new CachedDiscogsClient({ setKV: vi.fn() } as unknown as DiscogsClient, kv)
+    // Spy on the internal searchCollection so we can control page responses
+    mockSearchCollection = vi.fn()
+    vi.spyOn(client as never, 'searchCollection').mockImplementation(mockSearchCollection)
+  })
+
+  it('returns pagination.items equal to the real Discogs total, not truncated count', async () => {
+    // 40 pages = 4000 items, but maxPages default is 50, so all pages are fetched
+    const totalItems = 4000
+    const totalPages = 40
+    mockSearchCollection.mockImplementation((_u: string, _a: string, _s: string, opts: { page: number }) => {
+      return Promise.resolve(makePageResponse(opts.page, totalPages, totalItems))
+    })
+
+    const result = await client.getCompleteCollection('user', 'token', 'secret', 'key', 'consumerSecret')
+
+    expect(result.pagination.items).toBe(4000)
+    expect(result.releases).toHaveLength(4000)
+    expect(mockSearchCollection).toHaveBeenCalledTimes(40)
+  })
+
+  it('reports actual total even when collection exceeds maxPages cap', async () => {
+    // 70 pages = 7000 items, exceeds default maxPages=50
+    const totalItems = 7000
+    const totalPages = 70
+    mockSearchCollection.mockImplementation((_u: string, _a: string, _s: string, opts: { page: number }) => {
+      return Promise.resolve(makePageResponse(opts.page, totalPages, totalItems))
+    })
+
+    const result = await client.getCompleteCollection('user', 'token', 'secret', 'key', 'consumerSecret')
+
+    // pagination.items should be the REAL Discogs total (7000), not truncated count (5000)
+    expect(result.pagination.items).toBe(7000)
+    // Only 50 pages fetched due to maxPages cap (5000 items at 100/page)
+    expect(mockSearchCollection).toHaveBeenCalledTimes(50)
+  })
+
+  it('logs a warning when collection is truncated', async () => {
+    const consoleSpy = vi.spyOn(console, 'log')
+    const totalItems = 6000
+    mockSearchCollection.mockImplementation((_u: string, _a: string, _s: string, opts: { page: number }) => {
+      return Promise.resolve(makePageResponse(opts.page, 60, totalItems))
+    })
+
+    await client.getCompleteCollection('user', 'token', 'secret', 'key', 'consumerSecret')
+
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('truncated'))
+  })
+
+  it('does NOT log a truncation warning when full collection fits within maxPages', async () => {
+    const consoleSpy = vi.spyOn(console, 'log')
+    mockSearchCollection.mockImplementation((_u: string, _a: string, _s: string, opts: { page: number }) => {
+      return Promise.resolve(makePageResponse(opts.page, 10, 1000)) // 1000 items, 10 pages
+    })
+
+    await client.getCompleteCollection('user', 'token', 'secret', 'key', 'consumerSecret')
+
+    const truncationLogs = consoleSpy.mock.calls.filter(args => String(args[0]).includes('truncated'))
+    expect(truncationLogs).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
Closes #6

## Summary
- Raises collection index cap from 2,500 to 5,000 items (`maxPages` 25→50)
- Fixes `pagination.items` to report the real Discogs total, not the truncated count
- Fixes broken truncation detection (was comparing clamped value to itself)
- Fixes `collections` KV TTL from 30min to 45min to match intended cache window
- Adds truncation warnings in `get_collection_stats` and `search_collection` output when a collection exceeds the indexed portion

## Test plan
- [ ] Confirm 72+ tests pass (68 existing + 4 new `CachedDiscogsClient` tests)
- [ ] Manual test with a 4000+ item collection: `get_collection_stats` should report correct total; `search_collection` should find all matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)