### PR TITLE
fix(auth): include query params in OAuth signature base string

### DIFF
--- a/src/auth/discogs.ts
+++ b/src/auth/discogs.ts
@@ -97,16 +97,28 @@ export class DiscogsAuth {
 	}
 
 	/**
-	 * Create OAuth signature base string
+	 * Create OAuth signature base string per RFC 5849 §3.4.1.
+	 * The base string URI excludes any query string; query parameters are
+	 * extracted and merged with the supplied parameters before sorting.
 	 */
 	private createSignatureBaseString(method: string, url: string, parameters: Record<string, string>): string {
-		// Sort parameters by key
-		const sortedParams = Object.keys(parameters)
-			.sort()
-			.map((key) => `${percentEncode(key)}=${percentEncode(parameters[key])}`)
+		const parsed = new URL(url)
+		const baseUrl = `${parsed.protocol}//${parsed.host}${parsed.pathname}`
+
+		const allParams: Array<[string, string]> = []
+		for (const [key, value] of parsed.searchParams) {
+			allParams.push([percentEncode(key), percentEncode(value)])
+		}
+		for (const [key, value] of Object.entries(parameters)) {
+			allParams.push([percentEncode(key), percentEncode(value)])
+		}
+
+		const sortedParams = allParams
+			.sort(([k1, v1], [k2, v2]) => (k1 < k2 ? -1 : k1 > k2 ? 1 : v1 < v2 ? -1 : v1 > v2 ? 1 : 0))
+			.map(([k, v]) => `${k}=${v}`)
 			.join('&')
 
-		return `${method}&${percentEncode(url)}&${percentEncode(sortedParams)}`
+		return `${method}&${percentEncode(baseUrl)}&${percentEncode(sortedParams)}`
 	}
 
 	/**

--- a/src/auth/discogs.ts
+++ b/src/auth/discogs.ts
@@ -114,7 +114,13 @@ export class DiscogsAuth {
 		}
 
 		const sortedParams = allParams
-			.sort(([k1, v1], [k2, v2]) => (k1 < k2 ? -1 : k1 > k2 ? 1 : v1 < v2 ? -1 : v1 > v2 ? 1 : 0))
+			.sort(([k1, v1], [k2, v2]) => {
+				if (k1 < k2) return -1
+				if (k1 > k2) return 1
+				if (v1 < v2) return -1
+				if (v1 > v2) return 1
+				return 0
+			})
 			.map(([k, v]) => `${k}=${v}`)
 			.join('&')
 

--- a/test/auth/discogs.spec.ts
+++ b/test/auth/discogs.spec.ts
@@ -188,5 +188,30 @@ describe('DiscogsAuth', () => {
 
 			expect(headers1.Authorization).toBe(headers2.Authorization)
 		})
+
+		it('should include URL query parameters in the signature base string', async () => {
+			vi.spyOn(Date, 'now').mockReturnValue(new Date('2023-01-01T00:00:00Z').getTime())
+			vi.spyOn(Math, 'random').mockReturnValue(0.5)
+
+			const token = { key: 'test-token', secret: 'test-secret' }
+			const extractSig = (auth: string) => /oauth_signature="([^"]+)"/.exec(auth)?.[1]
+
+			const withQuery = await auth.getAuthHeaders(
+				'https://api.discogs.com/users/x/collection/folders/0/releases?page=1&per_page=100',
+				'GET',
+				token,
+			)
+			const withoutQuery = await auth.getAuthHeaders('https://api.discogs.com/users/x/collection/folders/0/releases', 'GET', token)
+			const reorderedQuery = await auth.getAuthHeaders(
+				'https://api.discogs.com/users/x/collection/folders/0/releases?per_page=100&page=1',
+				'GET',
+				token,
+			)
+
+			// Query parameters must affect the signature (otherwise Discogs rejects the request).
+			expect(extractSig(withQuery.Authorization)).not.toBe(extractSig(withoutQuery.Authorization))
+			// Query parameter order must not matter (signing sorts them).
+			expect(extractSig(withQuery.Authorization)).toBe(extractSig(reorderedQuery.Authorization))
+		})
 	})
 })


### PR DESCRIPTION
## Summary

Authenticated requests to any Discogs endpoint with a query string (e.g. `get_collection_stats`, `search_collection`, `list_folders` for a folder beyond the first page) currently fail with HTTP 403 *"You are not allowed to view this resource. Please authenticate as the owner."* even when the user is correctly logged in. `auth_status` reports the session as authenticated because the only round-trip it makes (`/oauth/identity`) has no query string.

## Root cause

`createSignatureBaseString` in `src/auth/discogs.ts` percent-encodes the full request URL — including the query string — as the base string URI, and never extracts the query parameters into the signing parameter list. Per [RFC 5849 §3.4.1](https://datatracker.ietf.org/doc/html/rfc5849#section-3.4.1), the base string URI must be scheme + authority + path only, and any query (or `application/x-www-form-urlencoded` body) parameters must be merged with the OAuth parameters and sorted before signing.

Because of this:

- `/oauth/identity` (no query string) → signature is valid → 200
- `/users/{u}/collection/folders/0/releases?page=1&per_page=100&sort=added&sort_order=desc` → signature is invalid → Discogs falls back to anonymous access → private-resource 403

## Fix

Parse the URL with the WHATWG `URL` constructor, use `scheme://host + pathname` as the base URI, decode query params via `URL.searchParams`, merge them with the caller-supplied OAuth params, then sort by encoded key (with encoded value as tiebreaker) before constructing the base string.

A regression test in `test/auth/discogs.spec.ts` asserts:

1. Query parameters change the produced `oauth_signature` (i.e., they are now part of the base string).
2. Reordering query parameters produces the same `oauth_signature` (i.e., parameter normalization is correct).

## Verification

- `npm run lint` ✅
- `npm test` ✅ (229/229)
- `npm run build` ✅
- Deployed against my own self-hosted instance with the previously-failing session; `get_collection_stats` returned full results.

## Test plan

- [ ] CI is green (lint, test, build)
- [ ] On a fresh deploy, `get_collection_stats` returns stats for the authenticated user instead of HTTP 403
- [ ] `search_collection` (with and without a query) returns results
- [ ] `auth_status` continues to behave as before