### PR TITLE
feat(auth): add ALLOWED_DISCOGS_USERNAMES — resolve usernames to IDs at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,18 +61,26 @@ https://discogs-mcp.<your-subdomain>.workers.dev/discogs-callback
 
 ### 4. (Optional but recommended) Lock your instance to your own Discogs user
 
-By default, anyone who discovers your Worker URL can authenticate and consume your Discogs rate-limit budget. To restrict it, edit `wrangler.toml` in your fork and set `ALLOWED_DISCOGS_USER_ID` under `[vars]`:
+By default, anyone who discovers your Worker URL can authenticate and consume your Discogs rate-limit budget. To restrict it, edit `wrangler.toml` in your fork and set `ALLOWED_DISCOGS_USERNAMES` under `[vars]`:
 
 ```toml
 [vars]
-# Single user
-ALLOWED_DISCOGS_USER_ID = "123456"
+# Single user — the Worker resolves the username to a numeric ID automatically
+ALLOWED_DISCOGS_USERNAMES = "your-discogs-username"
 
 # Or a comma-separated list for multiple users
-ALLOWED_DISCOGS_USER_ID = "123456,789012,345678"
+ALLOWED_DISCOGS_USERNAMES = "alice,bob,carol"
 ```
 
-Find your numeric ID by visiting `https://api.discogs.com/users/<your-username>` and looking at the `id` field. Push the change — Workers Builds redeploys automatically.
+Push the change — Workers Builds redeploys automatically. The Worker looks up each username via the Discogs API on first use and caches the result for 7 days, so there's no manual ID lookup required.
+
+If you prefer to supply numeric Discogs user IDs directly (find yours at `https://api.discogs.com/users/<your-username>`, field `id`), use `ALLOWED_DISCOGS_USER_ID` instead — or set both; entries from either var are merged:
+
+```toml
+[vars]
+ALLOWED_DISCOGS_USER_ID = "123456"
+ALLOWED_DISCOGS_USERNAMES = "carol"
+```
 
 ### 5. Connect your MCP client
 

--- a/src/auth/oauth-handler.ts
+++ b/src/auth/oauth-handler.ts
@@ -5,6 +5,7 @@ import type { ExecutionContext } from '@cloudflare/workers-types'
 import { DiscogsAuth } from './discogs'
 import type { Env } from '../types/env'
 import { tokenMirrorKey } from '../sync/keys'
+import { parseUsernameList, resolveUsernamesToIds } from './usernameResolver'
 
 // Env with OAuth helpers injected by the provider at runtime
 interface OAuthEnv extends Env {
@@ -35,17 +36,27 @@ export function parseAllowlist(raw: string | undefined): string[] {
 }
 
 /**
- * If ALLOWED_DISCOGS_USER_ID is set (non-empty), verify that the authenticated
- * Discogs identity matches one of the allowed IDs. Returns a 403 response for
- * unauthorized users, or null to proceed. Empty/unset = open instance.
+ * If either ALLOWED_DISCOGS_USER_ID or ALLOWED_DISCOGS_USERNAMES is non-empty,
+ * verify that the authenticated Discogs identity matches one of the allowed
+ * numeric IDs (after resolving usernames via the public Discogs API).
+ * Returns a 403 response for unauthorized users, or null to proceed.
+ * Empty/unset on both = open instance.
  */
-export function checkAllowlist(
+export async function checkAllowlist(
   identity: { id: number; username: string },
   allowedIdRaw: string | undefined,
-): Response | null {
-  const allowed = parseAllowlist(allowedIdRaw)
-  if (allowed.length === 0) return null
-  if (allowed.includes(String(identity.id))) return null
+  allowedUsernamesRaw: string | undefined,
+  kv: KVNamespace,
+): Promise<Response | null> {
+  const numericIds = parseAllowlist(allowedIdRaw)
+  const parsedUsernames = parseUsernameList(allowedUsernamesRaw)
+  // Open instance only when neither var is configured at all.
+  // If a var is set but resolution fails (e.g. network error or 404), deny
+  // rather than falling back to open — misconfigured allowlist ≠ no allowlist.
+  if (numericIds.length === 0 && parsedUsernames.length === 0) return null
+  const usernameIds = await resolveUsernamesToIds(parsedUsernames, kv)
+  const allowed = new Set([...numericIds, ...usernameIds])
+  if (allowed.has(String(identity.id))) return null
 
   console.warn(
     `[AUTH] Rejected unauthorized user: ${identity.username} (${identity.id})`,
@@ -181,7 +192,12 @@ async function handleDiscogsCallback(request: Request, env: OAuthEnv): Promise<R
     const identity = await identityRes.json() as { id: number; username: string }
 
     // Allowlist gate (set on maintainer's deployment; empty = open)
-    const denied = checkAllowlist(identity, env.ALLOWED_DISCOGS_USER_ID)
+    const denied = await checkAllowlist(
+      identity,
+      env.ALLOWED_DISCOGS_USER_ID,
+      env.ALLOWED_DISCOGS_USERNAMES,
+      env.MCP_SESSIONS,
+    )
     if (denied) return denied
 
     const userProps: DiscogsUserProps = {
@@ -353,7 +369,12 @@ async function handleManualCallback(request: Request, env: OAuthEnv): Promise<Re
     const identity = await identityRes.json() as { id: number; username: string }
 
     // Allowlist gate (set on maintainer's deployment; empty = open)
-    const denied = checkAllowlist(identity, env.ALLOWED_DISCOGS_USER_ID)
+    const denied = await checkAllowlist(
+      identity,
+      env.ALLOWED_DISCOGS_USER_ID,
+      env.ALLOWED_DISCOGS_USERNAMES,
+      env.MCP_SESSIONS,
+    )
     if (denied) return denied
 
     // Store session in KV (7 days)

--- a/src/auth/oauth-handler.ts
+++ b/src/auth/oauth-handler.ts
@@ -54,6 +54,9 @@ export async function checkAllowlist(
   // If a var is set but resolution fails (e.g. network error or 404), deny
   // rather than falling back to open — misconfigured allowlist ≠ no allowlist.
   if (numericIds.length === 0 && parsedUsernames.length === 0) return null
+  // Fast path: if the caller's numeric ID is already in the static list, skip
+  // username resolution entirely (avoids a fetch-per-name fan-out on cold isolates).
+  if (numericIds.includes(String(identity.id))) return null
   const usernameIds = await resolveUsernamesToIds(parsedUsernames, kv)
   const allowed = new Set([...numericIds, ...usernameIds])
   if (allowed.has(String(identity.id))) return null

--- a/src/auth/usernameResolver.ts
+++ b/src/auth/usernameResolver.ts
@@ -1,0 +1,96 @@
+// ABOUTME: Resolves Discogs usernames to numeric user IDs via the public
+// ABOUTME: GET /users/{username} endpoint, with module-level + KV caching.
+import { fetchWithRetry } from '../utils/retry'
+
+const USER_AGENT = 'discogs-mcp/1.0.0'
+const KV_PREFIX = 'username-id:'
+const KV_TTL_SECONDS = 7 * 24 * 60 * 60 // 7 days
+
+const hotCache = new Map<string, string>()
+
+/**
+ * Parse ALLOWED_DISCOGS_USERNAMES into a list of normalized usernames.
+ * Accepts a single name ("jhuggart") or a comma-separated list ("a,b,c").
+ * Trims whitespace, lowercases, drops empties. Empty/unset returns [].
+ */
+export function parseUsernameList(raw: string | undefined): string[] {
+  return (raw ?? '')
+    .split(',')
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean)
+}
+
+/**
+ * Resolve a list of Discogs usernames to numeric user IDs (as strings).
+ *
+ * Lookup order per username: module-level Map → KV (`username-id:<name>`) →
+ * `GET https://api.discogs.com/users/<name>`. Successful resolutions populate
+ * both caches (KV with a 7-day TTL). Failures are logged and silently dropped
+ * from the result; failures are NOT cached so a typo can be fixed by editing
+ * config without waiting out a stale negative entry.
+ *
+ * Lookups are issued in parallel via Promise.all.
+ */
+export async function resolveUsernamesToIds(
+  usernames: string[],
+  kv: KVNamespace,
+): Promise<string[]> {
+  if (usernames.length === 0) return []
+
+  const results = await Promise.all(
+    usernames.map((name) => resolveOne(name, kv)),
+  )
+
+  return results.filter((id): id is string => id !== null)
+}
+
+async function resolveOne(username: string, kv: KVNamespace): Promise<string | null> {
+  const cached = hotCache.get(username)
+  if (cached) return cached
+
+  try {
+    const fromKv = await kv.get(`${KV_PREFIX}${username}`)
+    if (fromKv) {
+      hotCache.set(username, fromKv)
+      return fromKv
+    }
+  } catch (error) {
+    console.warn(`[username-resolver] KV read failed for ${username}:`, error)
+  }
+
+  try {
+    const response = await fetchWithRetry(
+      `https://api.discogs.com/users/${encodeURIComponent(username)}`,
+      {
+        headers: {
+          'User-Agent': USER_AGENT,
+          Accept: 'application/json',
+        },
+      },
+    )
+    const body = (await response.json()) as { id?: number }
+    if (typeof body.id !== 'number') {
+      console.warn(`[username-resolver] No id in response for ${username}`)
+      return null
+    }
+
+    const id = String(body.id)
+    hotCache.set(username, id)
+    try {
+      await kv.put(`${KV_PREFIX}${username}`, id, { expirationTtl: KV_TTL_SECONDS })
+    } catch (error) {
+      console.warn(`[username-resolver] KV write failed for ${username}:`, error)
+    }
+    return id
+  } catch (error) {
+    console.warn(`[username-resolver] Failed to resolve ${username}:`, error)
+    return null
+  }
+}
+
+/**
+ * Test-only: clear the module-level hot cache between cases.
+ */
+export function _resetHotCacheForTests(): void {
+  hotCache.clear()
+}

--- a/src/auth/usernameResolver.ts
+++ b/src/auth/usernameResolver.ts
@@ -1,10 +1,14 @@
 // ABOUTME: Resolves Discogs usernames to numeric user IDs via the public
 // ABOUTME: GET /users/{username} endpoint, with module-level + KV caching.
 import { fetchWithRetry } from '../utils/retry'
+import { SERVER_VERSION } from '../version'
 
-const USER_AGENT = 'discogs-mcp/1.0.0'
+const USER_AGENT = `discogs-mcp/${SERVER_VERSION} (+https://github.com/rianvdm/discogs-mcp)`
 const KV_PREFIX = 'username-id:'
 const KV_TTL_SECONDS = 7 * 24 * 60 * 60 // 7 days
+// Cap retries on the auth path: a single Discogs blip would otherwise stall
+// the OAuth callback ~7s before fail-closing. 1 retry → 2 total attempts.
+const RESOLVE_MAX_RETRIES = 1
 
 const hotCache = new Map<string, string>()
 
@@ -67,6 +71,7 @@ async function resolveOne(username: string, kv: KVNamespace): Promise<string | n
           Accept: 'application/json',
         },
       },
+      { maxRetries: RESOLVE_MAX_RETRIES },
     )
     const body = (await response.json()) as { id?: number }
     if (typeof body.id !== 'number') {

--- a/src/index-oauth.ts
+++ b/src/index-oauth.ts
@@ -5,6 +5,7 @@ import type { ExecutionContext, ScheduledController } from '@cloudflare/workers-
 import { createMcpHandler } from 'agents/mcp'
 
 import { DiscogsOAuthHandler, parseAllowlist, type DiscogsUserProps } from './auth/oauth-handler'
+import { parseUsernameList, resolveUsernamesToIds } from './auth/usernameResolver'
 import { DiscogsClient } from './clients/discogs'
 import { MARKETING_PAGE_HTML } from './marketing-page.js'
 import { createMcpServer } from './mcp/server'
@@ -22,15 +23,18 @@ const SERVER_VERSION = '1.0.0'
 const ACCESS_TOKEN_TTL = 7 * 24 * 60 * 60
 
 /**
- * Enforce ALLOWED_DISCOGS_USER_ID on authenticated MCP requests.
- * Primary gate is at the OAuth callback, but we also check here so that any
- * pre-existing grants/sessions issued before the allowlist was set are
- * invalidated on their next request.
+ * Enforce ALLOWED_DISCOGS_USER_ID / ALLOWED_DISCOGS_USERNAMES on authenticated
+ * MCP requests. Primary gate is at the OAuth callback, but we also check here
+ * so that any pre-existing grants/sessions issued before the allowlist was set
+ * are invalidated on their next request.
  */
-function isAllowedUser(numericId: string | undefined, env: Env): boolean {
-  const allowed = parseAllowlist(env.ALLOWED_DISCOGS_USER_ID)
-  if (allowed.length === 0) return true
-  return !!numericId && allowed.includes(numericId)
+async function isAllowedUser(numericId: string | undefined, env: Env): Promise<boolean> {
+  const numericIds = parseAllowlist(env.ALLOWED_DISCOGS_USER_ID)
+  const parsedUsernames = parseUsernameList(env.ALLOWED_DISCOGS_USERNAMES)
+  if (numericIds.length === 0 && parsedUsernames.length === 0) return true
+  const usernameIds = await resolveUsernamesToIds(parsedUsernames, env.MCP_SESSIONS)
+  const allowed = new Set([...numericIds, ...usernameIds])
+  return !!numericId && allowed.has(numericId)
 }
 
 function accessDeniedResponse(): Response {
@@ -63,7 +67,7 @@ const oauthProvider = new OAuthProvider({
       const { server, setContext } = createMcpServer(env, baseUrl)
 
       const props = (ctx as unknown as { props?: DiscogsUserProps }).props
-      if (props && !isAllowedUser(props.numericId, env)) {
+      if (props && !(await isAllowedUser(props.numericId, env))) {
         return accessDeniedResponse()
       }
       if (props?.username && props?.accessToken) {
@@ -114,7 +118,7 @@ async function handleSessionBasedMcp(
 
   const sessionData = JSON.parse(sessionDataStr)
 
-  if (!isAllowedUser(sessionData.numericId, env)) {
+  if (!(await isAllowedUser(sessionData.numericId, env))) {
     // Delete the stale unauthorized session so retry fails cleanly with 401
     await env.MCP_SESSIONS.delete(`session:${sessionId}`)
     return accessDeniedResponse()
@@ -309,10 +313,12 @@ export default {
   },
 
   async scheduled(_event: ScheduledController, env: Env, _ctx: ExecutionContext): Promise<void> {
-    const allowed = (env.ALLOWED_DISCOGS_USER_ID || '')
-      .split(',')
-      .map((s) => s.trim())
-      .filter(Boolean)
+    const numericIds = parseAllowlist(env.ALLOWED_DISCOGS_USER_ID)
+    const usernameIds = await resolveUsernamesToIds(
+      parseUsernameList(env.ALLOWED_DISCOGS_USERNAMES),
+      env.MCP_SESSIONS,
+    )
+    const allowed = [...new Set([...numericIds, ...usernameIds])]
 
     for (const numericId of allowed) {
       try {

--- a/src/index-oauth.ts
+++ b/src/index-oauth.ts
@@ -32,6 +32,9 @@ async function isAllowedUser(numericId: string | undefined, env: Env): Promise<b
   const numericIds = parseAllowlist(env.ALLOWED_DISCOGS_USER_ID)
   const parsedUsernames = parseUsernameList(env.ALLOWED_DISCOGS_USERNAMES)
   if (numericIds.length === 0 && parsedUsernames.length === 0) return true
+  // Fast path: if the caller's numeric ID is already in the static list, skip
+  // username resolution entirely (avoids a fetch-per-name fan-out on cold isolates).
+  if (numericId && numericIds.includes(numericId)) return true
   const usernameIds = await resolveUsernamesToIds(parsedUsernames, env.MCP_SESSIONS)
   const allowed = new Set([...numericIds, ...usernameIds])
   return !!numericId && allowed.has(numericId)

--- a/src/types/env.ts
+++ b/src/types/env.ts
@@ -13,6 +13,12 @@ export interface Env {
   // Empty / unset = no allowlist (open instance, for self-hosters and local dev).
   ALLOWED_DISCOGS_USER_ID?: string
 
+  // Optional allowlist by Discogs username (resolved to numeric ID at runtime
+  // via GET /users/<name>, cached in MCP_SESSIONS for 7 days).
+  // Accepts a single name ("jhuggart") or comma-separated list ("a,b,c").
+  // Merged with ALLOWED_DISCOGS_USER_ID. Empty/unset on both = open instance.
+  ALLOWED_DISCOGS_USERNAMES?: string
+
   // Optional debug token for the GET /debug/budget endpoint.
   // If unset, the debug endpoint returns 404 (no surface area exposed).
   // Set via `wrangler secret put DEBUG_TOKEN --env production` with any random string.

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,3 @@
+// ABOUTME: Shared server-version constant. Imported anywhere that needs to
+// ABOUTME: identify itself in a User-Agent or version-stamped log line.
+export const SERVER_VERSION = '1.0.0'

--- a/test/auth/oauth-handler.spec.ts
+++ b/test/auth/oauth-handler.spec.ts
@@ -1,6 +1,6 @@
 // ABOUTME: Tests for DiscogsOAuthHandler auth routes.
 import { env, createExecutionContext, waitOnExecutionContext } from 'cloudflare:test'
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { DiscogsOAuthHandler, checkAllowlist } from '../../src/auth/oauth-handler'
 import { tokenMirrorKey } from '../../src/sync/keys'
 
@@ -25,26 +25,30 @@ vi.stubGlobal('fetch', mockFetch)
 
 describe('checkAllowlist', () => {
   const identity = { id: 2579319, username: 'elezea-records' }
+  const stubKv = {
+    get: vi.fn().mockResolvedValue(null),
+    put: vi.fn().mockResolvedValue(undefined),
+  } as unknown as KVNamespace
 
-  it('returns null when allowlist is unset (open instance)', () => {
-    expect(checkAllowlist(identity, undefined)).toBeNull()
+  it('returns null when allowlist is unset (open instance)', async () => {
+    expect(await checkAllowlist(identity, undefined, undefined, stubKv)).toBeNull()
   })
 
-  it('returns null when allowlist is empty string (open instance)', () => {
-    expect(checkAllowlist(identity, '')).toBeNull()
-    expect(checkAllowlist(identity, '   ')).toBeNull()
+  it('returns null when allowlist is empty string (open instance)', async () => {
+    expect(await checkAllowlist(identity, '', '', stubKv)).toBeNull()
+    expect(await checkAllowlist(identity, '   ', '   ', stubKv)).toBeNull()
   })
 
-  it('returns null when numeric ID matches', () => {
-    expect(checkAllowlist(identity, '2579319')).toBeNull()
+  it('returns null when numeric ID matches', async () => {
+    expect(await checkAllowlist(identity, '2579319', undefined, stubKv)).toBeNull()
   })
 
-  it('trims whitespace before comparing', () => {
-    expect(checkAllowlist(identity, '  2579319  ')).toBeNull()
+  it('trims whitespace before comparing', async () => {
+    expect(await checkAllowlist(identity, '  2579319  ', undefined, stubKv)).toBeNull()
   })
 
   it('returns a 403 HTML response when numeric ID does not match', async () => {
-    const res = checkAllowlist(identity, '99999')
+    const res = await checkAllowlist(identity, '99999', undefined, stubKv)
     expect(res).not.toBeNull()
     expect(res!.status).toBe(403)
     expect(res!.headers.get('Content-Type')).toContain('text/html')
@@ -53,32 +57,127 @@ describe('checkAllowlist', () => {
     expect(body).toContain('github.com/rianvdm/discogs-mcp')
   })
 
-  it('compares by numeric ID, not username (usernames are mutable)', () => {
-    const res = checkAllowlist({ id: 111, username: 'elezea-records' }, '2579319')
+  it('compares by numeric ID, not username (usernames are mutable)', async () => {
+    const res = await checkAllowlist(
+      { id: 111, username: 'elezea-records' },
+      '2579319',
+      undefined,
+      stubKv,
+    )
     expect(res).not.toBeNull()
     expect(res!.status).toBe(403)
   })
 
-  it('accepts a comma-separated list and allows any match', () => {
-    expect(checkAllowlist(identity, '111,2579319,222')).toBeNull()
-    expect(checkAllowlist({ id: 111, username: 'a' }, '111,2579319,222')).toBeNull()
-    expect(checkAllowlist({ id: 222, username: 'b' }, '111,2579319,222')).toBeNull()
+  it('accepts a comma-separated list and allows any match', async () => {
+    expect(await checkAllowlist(identity, '111,2579319,222', undefined, stubKv)).toBeNull()
+    expect(
+      await checkAllowlist({ id: 111, username: 'a' }, '111,2579319,222', undefined, stubKv),
+    ).toBeNull()
+    expect(
+      await checkAllowlist({ id: 222, username: 'b' }, '111,2579319,222', undefined, stubKv),
+    ).toBeNull()
   })
 
-  it('rejects when numeric ID is absent from the list', () => {
-    const res = checkAllowlist({ id: 999, username: 'nope' }, '111,2579319,222')
+  it('rejects when numeric ID is absent from the list', async () => {
+    const res = await checkAllowlist(
+      { id: 999, username: 'nope' },
+      '111,2579319,222',
+      undefined,
+      stubKv,
+    )
     expect(res).not.toBeNull()
     expect(res!.status).toBe(403)
   })
 
-  it('trims whitespace around list entries', () => {
-    expect(checkAllowlist(identity, ' 111 , 2579319 , 222 ')).toBeNull()
+  it('trims whitespace around list entries', async () => {
+    expect(
+      await checkAllowlist(identity, ' 111 , 2579319 , 222 ', undefined, stubKv),
+    ).toBeNull()
   })
 
-  it('ignores empty entries in the list (e.g. trailing commas)', () => {
-    expect(checkAllowlist(identity, '2579319,,,')).toBeNull()
-    const res = checkAllowlist({ id: 999, username: 'nope' }, ',,,')
+  it('ignores empty entries in the list (e.g. trailing commas)', async () => {
+    expect(await checkAllowlist(identity, '2579319,,,', undefined, stubKv)).toBeNull()
+    const res = await checkAllowlist(
+      { id: 999, username: 'nope' },
+      ',,,',
+      undefined,
+      stubKv,
+    )
     expect(res).toBeNull() // all-empty = open instance
+  })
+})
+
+describe('checkAllowlist with usernames', () => {
+  const identity = { id: 2579319, username: 'elezea-records' }
+
+  function makeKv() {
+    const store = new Map<string, string>()
+    return {
+      get: vi.fn(async (key: string) => store.get(key) ?? null),
+      put: vi.fn(async (key: string, value: string) => {
+        store.set(key, value)
+      }),
+      _store: store,
+    } as unknown as KVNamespace & { _store: Map<string, string> }
+  }
+
+  beforeEach(async () => {
+    mockFetch.mockReset()
+    const { _resetHotCacheForTests } = await import('../../src/auth/usernameResolver')
+    _resetHotCacheForTests()
+  })
+
+  it('allows when only ALLOWED_DISCOGS_USERNAMES matches (resolved via fetch)', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ id: 2579319, username: 'elezea-records' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    const kv = makeKv()
+    const res = await checkAllowlist(identity, undefined, 'elezea-records', kv)
+    expect(res).toBeNull()
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    expect(mockFetch.mock.calls[0][0]).toBe('https://api.discogs.com/users/elezea-records')
+    // KV cache populated for cross-isolate reuse
+    expect(await kv.get('username-id:elezea-records')).toBe('2579319')
+  })
+
+  it('merges username and numeric-id allowlists', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ id: 111, username: 'somebody' }), { status: 200 }),
+    )
+    const kv = makeKv()
+    // identity (2579319) matches the numeric list; username 'somebody' is also allowed
+    const res = await checkAllowlist(identity, '2579319', 'somebody', kv)
+    expect(res).toBeNull()
+  })
+
+  it('rejects when username resolution fails (404) and no other entry matches', async () => {
+    mockFetch.mockResolvedValueOnce(new Response('Not Found', { status: 404 }))
+    const kv = makeKv()
+    const res = await checkAllowlist(identity, undefined, 'definitelynotreal', kv)
+    expect(res).not.toBeNull()
+    expect(res!.status).toBe(403)
+  })
+
+  it('uses KV cache on second call without re-fetching', async () => {
+    const kv = makeKv()
+    await kv.put('username-id:elezea-records', '2579319')
+    const res = await checkAllowlist(identity, undefined, 'elezea-records', kv)
+    expect(res).toBeNull()
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('lowercases the username before lookup', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ id: 2579319, username: 'elezea-records' }), { status: 200 }),
+    )
+    const kv = makeKv()
+    const res = await checkAllowlist(identity, undefined, 'Elezea-Records', kv)
+    expect(res).toBeNull()
+    expect(mockFetch.mock.calls[0][0]).toBe('https://api.discogs.com/users/elezea-records')
+    expect(await kv.get('username-id:elezea-records')).toBe('2579319')
   })
 })
 

--- a/test/auth/oauth-handler.spec.ts
+++ b/test/auth/oauth-handler.spec.ts
@@ -169,6 +169,17 @@ describe('checkAllowlist with usernames', () => {
     expect(mockFetch).not.toHaveBeenCalled()
   })
 
+  it('short-circuits when numeric ID already matches static list (no fetch, no KV read)', async () => {
+    // When the caller's numeric ID is already accepted by ALLOWED_DISCOGS_USER_ID,
+    // there's no reason to resolve any usernames — every cold isolate would
+    // otherwise fan out a fetch per configured username before answering.
+    const kv = makeKv()
+    const res = await checkAllowlist(identity, '2579319', 'alice,bob,carol', kv)
+    expect(res).toBeNull()
+    expect(mockFetch).not.toHaveBeenCalled()
+    expect(kv.get).not.toHaveBeenCalled()
+  })
+
   it('lowercases the username before lookup', async () => {
     mockFetch.mockResolvedValueOnce(
       new Response(JSON.stringify({ id: 2579319, username: 'elezea-records' }), { status: 200 }),

--- a/test/auth/usernameResolver.spec.ts
+++ b/test/auth/usernameResolver.spec.ts
@@ -71,7 +71,10 @@ describe('resolveUsernamesToIds', () => {
 
     expect(mockFetch).toHaveBeenCalledTimes(1)
     expect(mockFetch.mock.calls[0][0]).toBe('https://api.discogs.com/users/elezea-records')
-    expect(mockFetch.mock.calls[0][1].headers['User-Agent']).toBe('discogs-mcp/1.0.0')
+    // User-Agent identifies the app + version + repo per Discogs API guidance.
+    expect(mockFetch.mock.calls[0][1].headers['User-Agent']).toMatch(
+      /^discogs-mcp\/\d+\.\d+\.\d+ \(\+https:\/\/github\.com\/rianvdm\/discogs-mcp\)$/,
+    )
 
     expect(kv.put).toHaveBeenCalledWith(
       'username-id:elezea-records',
@@ -147,6 +150,20 @@ describe('resolveUsernamesToIds', () => {
     expect(result.sort()).toEqual(['1', '3'])
     expect(mockFetch).toHaveBeenCalledTimes(3)
   })
+
+  it('caps retries at 1 for transient 5xx so the auth path fails fast', async () => {
+    // Default fetchWithRetry would retry 3 times with exponential backoff (~7s),
+    // tying up an OAuth callback on a single Discogs blip. Resolution failures
+    // here just deny the user — there's no recovery benefit to long retries.
+    // mockImplementation (not mockResolvedValue) so each retry gets a fresh
+    // Response — Response bodies lock after first read.
+    mockFetch.mockImplementation(async () => new Response('upstream busy', { status: 503 }))
+    const kv = makeKv()
+    const result = await resolveUsernamesToIds(['transient'], kv)
+    expect(result).toEqual([])
+    // 1 retry → 2 total attempts (initial + retry)
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+  }, 10_000)
 
   it('treats KV read errors as a cache miss and proceeds to fetch', async () => {
     mockFetch.mockResolvedValueOnce(

--- a/test/auth/usernameResolver.spec.ts
+++ b/test/auth/usernameResolver.spec.ts
@@ -1,0 +1,163 @@
+// ABOUTME: Unit tests for the Discogs username → numeric ID resolver.
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  parseUsernameList,
+  resolveUsernamesToIds,
+  _resetHotCacheForTests,
+} from '../../src/auth/usernameResolver'
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+function makeKv() {
+  const store = new Map<string, string>()
+  return {
+    get: vi.fn(async (key: string) => store.get(key) ?? null),
+    put: vi.fn(async (key: string, value: string, _opts?: { expirationTtl?: number }) => {
+      store.set(key, value)
+    }),
+    _store: store,
+  } as unknown as KVNamespace & {
+    _store: Map<string, string>
+    get: ReturnType<typeof vi.fn>
+    put: ReturnType<typeof vi.fn>
+  }
+}
+
+beforeEach(() => {
+  mockFetch.mockReset()
+  _resetHotCacheForTests()
+})
+
+describe('parseUsernameList', () => {
+  it('returns [] for undefined / empty / whitespace', () => {
+    expect(parseUsernameList(undefined)).toEqual([])
+    expect(parseUsernameList('')).toEqual([])
+    expect(parseUsernameList('   ')).toEqual([])
+  })
+
+  it('splits on commas and trims', () => {
+    expect(parseUsernameList('a,b,c')).toEqual(['a', 'b', 'c'])
+    expect(parseUsernameList(' a , b , c ')).toEqual(['a', 'b', 'c'])
+  })
+
+  it('lowercases', () => {
+    expect(parseUsernameList('JHuggart,RianVDM')).toEqual(['jhuggart', 'rianvdm'])
+  })
+
+  it('drops empty entries (e.g. trailing commas)', () => {
+    expect(parseUsernameList('a,,b,')).toEqual(['a', 'b'])
+  })
+})
+
+describe('resolveUsernamesToIds', () => {
+  it('returns [] for an empty input list without touching KV or fetch', async () => {
+    const kv = makeKv()
+    expect(await resolveUsernamesToIds([], kv)).toEqual([])
+    expect(kv.get).not.toHaveBeenCalled()
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('fetches on cache miss, populates KV with 7-day TTL, returns numeric ID string', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ id: 2579319, username: 'elezea-records' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    const kv = makeKv()
+    const result = await resolveUsernamesToIds(['elezea-records'], kv)
+    expect(result).toEqual(['2579319'])
+
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    expect(mockFetch.mock.calls[0][0]).toBe('https://api.discogs.com/users/elezea-records')
+    expect(mockFetch.mock.calls[0][1].headers['User-Agent']).toBe('discogs-mcp/1.0.0')
+
+    expect(kv.put).toHaveBeenCalledWith(
+      'username-id:elezea-records',
+      '2579319',
+      { expirationTtl: 7 * 24 * 60 * 60 },
+    )
+  })
+
+  it('hits the hot cache on the second call', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ id: 111, username: 'a' }), { status: 200 }),
+    )
+    const kv = makeKv()
+    await resolveUsernamesToIds(['a'], kv)
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+
+    // Second call: hot cache hit; no fetch, no KV access
+    const kv2 = makeKv()
+    const result = await resolveUsernamesToIds(['a'], kv2)
+    expect(result).toEqual(['111'])
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    expect(kv2.get).not.toHaveBeenCalled()
+  })
+
+  it('hits the KV cache (no fetch) when hot cache is cold', async () => {
+    const kv = makeKv()
+    await kv.put('username-id:rianvdm', '12345')
+    _resetHotCacheForTests()
+
+    const result = await resolveUsernamesToIds(['rianvdm'], kv)
+    expect(result).toEqual(['12345'])
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('drops a username silently on 404 and does not cache the failure', async () => {
+    mockFetch.mockResolvedValueOnce(new Response('Not Found', { status: 404 }))
+    const kv = makeKv()
+    const result = await resolveUsernamesToIds(['nope'], kv)
+    expect(result).toEqual([])
+    expect(kv.put).not.toHaveBeenCalled()
+
+    // A subsequent call retries (no negative caching)
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ id: 7, username: 'nope' }), { status: 200 }),
+    )
+    const result2 = await resolveUsernamesToIds(['nope'], kv)
+    expect(result2).toEqual(['7'])
+  })
+
+  it('drops a username silently on a network error', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('network down'))
+    const kv = makeKv()
+    const result = await resolveUsernamesToIds(['boom'], kv)
+    expect(result).toEqual([])
+    expect(kv.put).not.toHaveBeenCalled()
+  })
+
+  it('resolves multiple usernames in parallel and preserves successes when one fails', async () => {
+    mockFetch.mockImplementation(async (url: string) => {
+      if (url.endsWith('/users/a')) {
+        return new Response(JSON.stringify({ id: 1, username: 'a' }), { status: 200 })
+      }
+      if (url.endsWith('/users/b')) {
+        return new Response('Not Found', { status: 404 })
+      }
+      if (url.endsWith('/users/c')) {
+        return new Response(JSON.stringify({ id: 3, username: 'c' }), { status: 200 })
+      }
+      throw new Error(`unexpected url: ${url}`)
+    })
+    const kv = makeKv()
+    const result = await resolveUsernamesToIds(['a', 'b', 'c'], kv)
+    expect(result.sort()).toEqual(['1', '3'])
+    expect(mockFetch).toHaveBeenCalledTimes(3)
+  })
+
+  it('treats KV read errors as a cache miss and proceeds to fetch', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ id: 9, username: 'x' }), { status: 200 }),
+    )
+    const failingKv = {
+      get: vi.fn().mockRejectedValue(new Error('kv unavailable')),
+      put: vi.fn().mockResolvedValue(undefined),
+    } as unknown as KVNamespace
+    const result = await resolveUsernamesToIds(['x'], failingKv)
+    expect(result).toEqual(['9'])
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+  })
+})

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -13,9 +13,15 @@ crons = ["0 * * * *"]
 
 # Optional allowlist: numeric Discogs user ID(s) permitted to authenticate.
 # Accepts a single ID or a comma-separated list (e.g. "123,456,789").
-# Empty = no allowlist (open; default for local dev and self-hosters).
+# Empty on both vars below = no allowlist (open; default for local dev and self-hosters).
+#
+# ALLOWED_DISCOGS_USERNAMES is the friendlier alternative — list Discogs
+# usernames (e.g. "jhuggart,rianvdm") and the Worker resolves each to its
+# numeric ID via GET /users/<name> (cached in MCP_SESSIONS for 7 days).
+# Both vars merge; entries on either are accepted.
 [vars]
 ALLOWED_DISCOGS_USER_ID = ""
+ALLOWED_DISCOGS_USERNAMES = ""
 
 # Durable Object for coordinated Discogs API rate limiting
 [durable_objects]
@@ -52,6 +58,7 @@ name = "discogs-mcp-prod"
 # Discogs API rate limits are too tight to share, so anyone else must self-host.
 [env.production.vars]
 ALLOWED_DISCOGS_USER_ID = "2579319,2316828"
+ALLOWED_DISCOGS_USERNAMES = ""
 
 [env.production.durable_objects]
 bindings = [


### PR DESCRIPTION
## Summary

- Adds `ALLOWED_DISCOGS_USERNAMES` env var so self-hosters can specify their Discogs username instead of manually looking up their numeric user ID
- The Worker resolves each username to a numeric ID via `GET /users/<name>` on first use, with two-level caching: module-level `Map` (hot isolate) + MCP_SESSIONS KV with a 7-day TTL
- Both vars merge — `ALLOWED_DISCOGS_USER_ID` and `ALLOWED_DISCOGS_USERNAMES` are fully interoperable; entries from either are accepted
- Security: if a username is configured but resolution fails (network error, 404 typo), the check **denies** rather than falling back to open access

## Changes

- `src/auth/usernameResolver.ts` — new: `parseUsernameList`, `resolveUsernamesToIds` with hot + KV caching
- `src/auth/oauth-handler.ts` — `checkAllowlist` is now async; accepts username raw + KV; merges resolved IDs
- `src/index-oauth.ts` — `isAllowedUser` is now async; same merge logic; scheduled handler updated
- `src/types/env.ts` — adds `ALLOWED_DISCOGS_USERNAMES?: string`
- `wrangler.toml` — adds empty `ALLOWED_DISCOGS_USERNAMES = ""` to dev and production `[vars]`
- `README.md` — §4 now leads with the username form; numeric ID documented as alternative
- `test/auth/usernameResolver.spec.ts` — new: 12 unit tests covering cache hits, failures, parallel resolution, lowercasing
- `test/auth/oauth-handler.spec.ts` — updated for async `checkAllowlist` signature; 5 new username-path cases

## Test plan

- [ ] All existing `checkAllowlist` tests pass with new async signature
- [ ] New resolver unit tests pass (fetch, KV cache hit, 404 drop, parallel, lowercasing)
- [ ] `ALLOWED_DISCOGS_USERNAMES = "rianvdm"` allows that account; denies others
- [ ] Resolution failure (bogus username) denies all users rather than opening the instance
- [ ] Mixing both vars (`ALLOWED_DISCOGS_USERNAMES = "a"` + `ALLOWED_DISCOGS_USER_ID = "123"`) allows both