### PR TITLE
fix(rate-limit): read Discogs identity off the session instead of refetching

### DIFF
--- a/src/mcp/resources/discogs.ts
+++ b/src/mcp/resources/discogs.ts
@@ -4,6 +4,7 @@ import { DiscogsClient } from '../../clients/discogs.js'
 import { CachedDiscogsClient } from '../../clients/cachedDiscogs.js'
 import type { DiscogsCollectionItem, DiscogsCollectionResponse } from '../../clients/discogs.js'
 import type { SessionContext } from '../server.js'
+import { sessionProfile } from '../session-profile.js'
 
 /**
  * Register Discogs resources with the MCP server
@@ -19,17 +20,6 @@ export function registerResources(server: McpServer, env: Env, getSessionContext
 	}
 	const cachedClient = env.MCP_SESSIONS ? new CachedDiscogsClient(discogsClient, env.MCP_SESSIONS) : null
 	const client = cachedClient || discogsClient
-
-	/** Helper: get profile for authenticated operations */
-	async function getProfileAndSetThrottle(session: { accessToken: string; accessTokenSecret: string }) {
-		const userProfile = await client.getUserProfile(
-			session.accessToken,
-			session.accessTokenSecret,
-			env.DISCOGS_CONSUMER_KEY,
-			env.DISCOGS_CONSUMER_SECRET,
-		)
-		return userProfile
-	}
 
 	// List available resources
 	server.registerResource(
@@ -47,7 +37,7 @@ export function registerResources(server: McpServer, env: Env, getSessionContext
 			}
 
 			try {
-				const userProfile = await getProfileAndSetThrottle(session)
+				const userProfile = sessionProfile(session)
 
 				// Use getCompleteCollection() when cached client is available
 				// to return the full collection (not just page 1) and benefit
@@ -173,7 +163,7 @@ export function registerResources(server: McpServer, env: Env, getSessionContext
 					throw new Error('Invalid search URI - query parameter is required')
 				}
 
-				const userProfile = await getProfileAndSetThrottle(session)
+				const userProfile = sessionProfile(session)
 
 				// When cached client is available, search against the cached
 				// complete collection instead of triggering a full pagination.

--- a/src/mcp/session-profile.ts
+++ b/src/mcp/session-profile.ts
@@ -1,0 +1,30 @@
+import type { SessionPayload } from './server.js'
+
+/** The authenticated user's Discogs identity, as carried on the session. */
+export interface SessionProfile {
+	username: string
+	numericId: string
+}
+
+/**
+ * Read the authenticated user's Discogs identity off the session.
+ *
+ * `/oauth/identity` is fetched exactly once, during the OAuth handshake
+ * (`src/auth/oauth-handler.ts`), and both fields are written onto every request
+ * context from there (`src/index-oauth.ts` -> `setContext`). Re-fetching them
+ * per tool invocation spent rate-limit budget on data we already hold, and a
+ * miss on that call's 6h cache was enough to trip the rate limiter's circuit
+ * breaker and take the server down for 10 minutes — see issue #45.
+ *
+ * This is deliberately synchronous: there is no network path here, and keeping
+ * it that way makes it obvious at every call site that no budget is at stake.
+ */
+export function sessionProfile(session: Pick<SessionPayload, 'username' | 'numericId'>): SessionProfile {
+	if (!session.username) {
+		// Unreachable via either auth path — both gate on a username before
+		// calling setContext — but failing loudly beats emitting requests to
+		// `/users//collection` and getting mystery 404s back.
+		throw new Error('Session is missing a Discogs username; re-authenticate to continue.')
+	}
+	return { username: session.username, numericId: session.numericId }
+}

--- a/src/mcp/tools/authenticated.ts
+++ b/src/mcp/tools/authenticated.ts
@@ -16,6 +16,7 @@ import { applySearchPipeline, type DedupedCollectionItem } from '../../utils/sea
 import { buildIndex, searchIndex } from '../../utils/searchIndex.js'
 import type { DiscogsCollectionItem } from '../../clients/discogs.js'
 import type { SessionContext } from '../server.js'
+import { sessionProfile } from '../session-profile.js'
 import { buildNextSteps } from '../../utils/breadcrumb.js'
 
 /**
@@ -294,19 +295,6 @@ export function registerAuthenticatedTools(server: McpServer, env: Env, getSessi
 	}
 	const cachedClient = env.MCP_SESSIONS ? new CachedDiscogsClient(discogsClient, env.MCP_SESSIONS) : null
 	const client = cachedClient || discogsClient
-
-	/**
-	 * Helper: get user profile for authenticated operations.
-	 */
-	async function getProfileAndSetThrottle(session: { accessToken: string; accessTokenSecret: string }) {
-		const userProfile = await client.getUserProfile(
-			session.accessToken,
-			session.accessTokenSecret,
-			env.DISCOGS_CONSUMER_KEY,
-			env.DISCOGS_CONSUMER_SECRET,
-		)
-		return userProfile
-	}
 
 	/**
 	 * Tool: search_collection
@@ -619,7 +607,7 @@ export function registerAuthenticatedTools(server: McpServer, env: Env, getSessi
 
 			try {
 				// Get user profile
-				const userProfile = await getProfileAndSetThrottle(session)
+				const userProfile = sessionProfile(session)
 
 				// Parse the query once. Disambiguation against the user's collection
 				// happens after we fetch it, in the cached branch below.
@@ -1036,7 +1024,7 @@ export function registerAuthenticatedTools(server: McpServer, env: Env, getSessi
 				let ownedReleaseIds = new Set<number>()
 				if (cachedClient) {
 					try {
-						const userProfile = await getProfileAndSetThrottle(session)
+						const userProfile = sessionProfile(session)
 						const toolStart = Date.now()
 						const TOOL_BUDGET_MS = 105000
 						let collection = await cachedClient.getCompleteCollection(
@@ -1113,7 +1101,7 @@ export function registerAuthenticatedTools(server: McpServer, env: Env, getSessi
 			}
 
 			try {
-				const userProfile = await getProfileAndSetThrottle(session)
+				const userProfile = sessionProfile(session)
 
 				// Compute stats from cached complete collection when available.
 				// This reuses the same cached dataset as search_collection and
@@ -1283,7 +1271,7 @@ export function registerAuthenticatedTools(server: McpServer, env: Env, getSessi
 				moodGenres = [...new Set(moodGenres)]
 				moodStyles = [...new Set(moodStyles)]
 
-				const userProfile = await getProfileAndSetThrottle(session)
+				const userProfile = sessionProfile(session)
 
 				// Get full collection for context-aware recommendations.
 				// Uses getCompleteCollectionReleases() when cached client is available
@@ -1768,7 +1756,7 @@ export function registerAuthenticatedTools(server: McpServer, env: Env, getSessi
 			}
 
 			try {
-				const userProfile = await getProfileAndSetThrottle(session)
+				const userProfile = sessionProfile(session)
 
 				const folders = await client.listFolders(
 					userProfile.username,
@@ -1826,7 +1814,7 @@ export function registerAuthenticatedTools(server: McpServer, env: Env, getSessi
 			}
 
 			try {
-				const userProfile = await getProfileAndSetThrottle(session)
+				const userProfile = sessionProfile(session)
 
 				const folder = await client.createFolder(
 					userProfile.username,
@@ -1881,7 +1869,7 @@ export function registerAuthenticatedTools(server: McpServer, env: Env, getSessi
 			}
 
 			try {
-				const userProfile = await getProfileAndSetThrottle(session)
+				const userProfile = sessionProfile(session)
 
 				const folder = await client.editFolder(
 					userProfile.username,
@@ -1935,7 +1923,7 @@ export function registerAuthenticatedTools(server: McpServer, env: Env, getSessi
 			}
 
 			try {
-				const userProfile = await getProfileAndSetThrottle(session)
+				const userProfile = sessionProfile(session)
 
 				await client.deleteFolder(
 					userProfile.username,
@@ -1989,7 +1977,7 @@ export function registerAuthenticatedTools(server: McpServer, env: Env, getSessi
 			}
 
 			try {
-				const userProfile = await getProfileAndSetThrottle(session)
+				const userProfile = sessionProfile(session)
 
 				const result = await client.addToFolder(
 					userProfile.username,
@@ -2047,7 +2035,7 @@ export function registerAuthenticatedTools(server: McpServer, env: Env, getSessi
 			}
 
 			try {
-				const userProfile = await getProfileAndSetThrottle(session)
+				const userProfile = sessionProfile(session)
 
 				await client.removeFromFolder(
 					userProfile.username,
@@ -2106,7 +2094,7 @@ export function registerAuthenticatedTools(server: McpServer, env: Env, getSessi
 			}
 
 			try {
-				const userProfile = await getProfileAndSetThrottle(session)
+				const userProfile = sessionProfile(session)
 
 				await client.editInstance(
 					userProfile.username,
@@ -2166,7 +2154,7 @@ export function registerAuthenticatedTools(server: McpServer, env: Env, getSessi
 			}
 
 			try {
-				const userProfile = await getProfileAndSetThrottle(session)
+				const userProfile = sessionProfile(session)
 
 				await client.editInstance(
 					userProfile.username,
@@ -2222,7 +2210,7 @@ export function registerAuthenticatedTools(server: McpServer, env: Env, getSessi
 			}
 
 			try {
-				const userProfile = await getProfileAndSetThrottle(session)
+				const userProfile = sessionProfile(session)
 
 				const fields = await client.listCustomFields(
 					userProfile.username,
@@ -2294,7 +2282,7 @@ export function registerAuthenticatedTools(server: McpServer, env: Env, getSessi
 			}
 
 			try {
-				const userProfile = await getProfileAndSetThrottle(session)
+				const userProfile = sessionProfile(session)
 
 				await client.editCustomFieldValue(
 					userProfile.username,
@@ -2344,7 +2332,7 @@ export function registerAuthenticatedTools(server: McpServer, env: Env, getSessi
 				return { content: [{ type: 'text', text: generateAuthInstructions(connectionId) }] }
 			}
 			try {
-				const userProfile = await getProfileAndSetThrottle(session)
+				const userProfile = sessionProfile(session)
 				const result = await client.getWantlist(
 					userProfile.username,
 					session.accessToken,
@@ -2389,7 +2377,7 @@ export function registerAuthenticatedTools(server: McpServer, env: Env, getSessi
 				return { content: [{ type: 'text', text: generateAuthInstructions(connectionId) }] }
 			}
 			try {
-				const userProfile = await getProfileAndSetThrottle(session)
+				const userProfile = sessionProfile(session)
 				const result = await client.addToWantlist(
 					userProfile.username,
 					release_id,
@@ -2429,7 +2417,7 @@ export function registerAuthenticatedTools(server: McpServer, env: Env, getSessi
 				return { content: [{ type: 'text', text: generateAuthInstructions(connectionId) }] }
 			}
 			try {
-				const userProfile = await getProfileAndSetThrottle(session)
+				const userProfile = sessionProfile(session)
 				await client.removeFromWantlist(
 					userProfile.username,
 					release_id,

--- a/test/mcp/session-profile.test.ts
+++ b/test/mcp/session-profile.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import { sessionProfile } from '../../src/mcp/session-profile'
+
+describe('sessionProfile', () => {
+	it('reads username and numericId straight off the session', () => {
+		expect(sessionProfile({ username: 'rianvdm', numericId: '12345' })).toEqual({
+			username: 'rianvdm',
+			numericId: '12345',
+		})
+	})
+
+	it('throws a re-auth error rather than returning an empty username', () => {
+		// An empty username would silently produce requests to `/users//collection`.
+		expect(() => sessionProfile({ username: '', numericId: '12345' })).toThrow(/re-authenticate/i)
+	})
+
+	it('is synchronous, so no call site can spend rate-limit budget on it', () => {
+		// Regression guard for #45: this used to be an async `/oauth/identity`
+		// fetch on the hot path of every authenticated tool.
+		const result = sessionProfile({ username: 'rianvdm', numericId: '12345' })
+		expect(result).not.toBeInstanceOf(Promise)
+	})
+})


### PR DESCRIPTION
Every authenticated tool called `/oauth/identity` through
`getProfileAndSetThrottle()` to learn the user's username. That data is
already on the session: the OAuth handshake fetches identity once
(src/auth/oauth-handler.ts) and `setContext` carries username + numericId
onto every request thereafter.

The call was KV-cached for 6h, so it was usually free — but a miss put a
live Discogs request on the hot path of every tool, including writes. On
2026-08-03 that's exactly what happened:

  17:00:05  [RL] Restored budget but stale (12859s old), reset to 60
  17:00:05  [RL] Budget updated: 60 -> 6/60
  17:00:06  [RL] Request: GET /oauth/identity  (throttled 3000ms)
  17:00:09  [RL] 429 (attempt 1/3, streak 1/3). Pausing 60000ms
  17:01:09  [RL] 429 (attempt 2/3, streak 2/3). Pausing 60000ms
  17:02:09  [RL] Circuit TRIPPED - 3 consecutive 429s, cooling down 600s

A redundant auth lookup tripped the circuit breaker and took the server
down for 10 minutes; the add_to_wantlist call that followed failed with
"Failed to get user profile: HTTP 429". It also blocked a search_discogs
call for >120s while it sat through both retry pauses.

Replace both copies of the helper (tools and resources had identical
bodies) with a shared synchronous `sessionProfile()`. Synchronous on
purpose: it makes it obvious at every call site that no rate-limit budget
is at stake. Throws on an empty username rather than silently emitting
requests to `/users//collection`.

The old name was also stale — it set no throttle, it only fetched.

Only `/oauth/identity` fetches left in src/ are the two in the OAuth
handshake, which correctly run once per authentication.

Closes #45. Does not address #46 or #47, which cover the escalation from
one 429 to a 10-minute outage.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

Verified: lint clean, `wrangler --dry-run` build clean, 273/273 tests pass (was 270).

Note: `src/mcp/tools/authenticated.ts` already fails `prettier --check` on `main`; left its formatting untouched rather than burying a small fix in a whole-file reformat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)