### PR TITLE
feat(rate-limit): route Discogs calls through a self-hosted egress relay

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -14,3 +14,12 @@
 DISCOGS_CONSUMER_KEY=
 DISCOGS_CONSUMER_SECRET=
 JWT_SECRET=
+
+# Optional — egress relay for Discogs API calls. Not needed to run the server.
+# Discogs throttles per source IP and Workers share Cloudflare's egress IPs; the
+# hosted instance routes its calls through a Cloudflare Tunnel to a machine with
+# an IP of its own, guarded by a Cloudflare Access service token. To use one,
+# set DISCOGS_RELAY_ORIGIN in wrangler.toml and these two as secrets:
+#   RELAY_ACCESS_CLIENT_ID     — Access service token client id (ends in ".access")
+#   RELAY_ACCESS_CLIENT_SECRET — Access service token client secret
+# See src/rate-limiter/relay.ts.

--- a/README.md
+++ b/README.md
@@ -142,6 +142,18 @@ npm run deploy
 
 Then follow steps 3–5 above (callback URL, optional allowlist, connect your MCP client).
 
+### Optional: route Discogs calls through your own IP
+
+Discogs throttles by source IP, and a Worker's outbound requests leave from Cloudflare's shared egress IPs, so other Workers talking to Discogs from the same location eat into your 60 requests a minute. You can see this when a first request after hours of idle already reports a low `X-Discogs-Ratelimit-Remaining`. If it bites, point the Worker at a relay you run: a Cloudflare Tunnel to any always-on machine (a home Mac, a small VPS) with a local reverse proxy that forwards to `https://api.discogs.com` and sets both `Host` and `X-Forwarded-Host` to `api.discogs.com` (cloudflared alone can't, it overwrites `X-Forwarded-Host`). Put a Cloudflare Access application with a service-token policy in front of the tunnel hostname, then:
+
+```bash
+# wrangler.toml: DISCOGS_RELAY_ORIGIN = "https://relay.example.com"
+wrangler secret put RELAY_ACCESS_CLIENT_ID
+wrangler secret put RELAY_ACCESS_CLIENT_SECRET
+```
+
+Leave `DISCOGS_RELAY_ORIGIN` empty to call Discogs directly (the default). If the relay is unreachable the Worker falls back to direct calls for that request and logs it, so a machine that is switched off degrades to the shared-IP behaviour rather than an outage. Implementation and rationale: `src/rate-limiter/relay.ts`.
+
 ## 🔐 Authentication
 
 This server uses **MCP OAuth 2.1** with Discogs as the identity provider. When you connect for the first time:

--- a/src/rate-limiter/durable-object.ts
+++ b/src/rate-limiter/durable-object.ts
@@ -1,5 +1,6 @@
 // src/rate-limiter/durable-object.ts
 import type { RateLimiterRequest, RateLimiterResponse, BudgetState, RequestPriority } from './types'
+import { relayConfigFrom, relayTarget, relayHeaders, isRelayLayerError, type RelayConfig, type RelayEnv } from './relay'
 
 const MAX_QUEUE_DEPTH = 20
 const QUEUE_TIMEOUT_MS = 90_000
@@ -228,9 +229,13 @@ export class DiscogsRateLimiter implements DurableObject {
   private consecutive429s = 0
   /** Wall-clock ms when cooldown ends; null = not tripped. Persisted. */
   private trippedUntil: number | null = null
+  /** Egress relay to send Discogs calls through; null = straight to api.discogs.com. */
+  private relay: RelayConfig | null
 
-  constructor(state: DurableObjectState) {
+  constructor(state: DurableObjectState, env: RelayEnv) {
     this.state = state
+    this.relay = relayConfigFrom(env)
+    console.log(this.relay ? `[RL] Egress relay enabled: ${this.relay.origin}` : '[RL] Egress relay off, calling api.discogs.com directly')
     state.blockConcurrencyWhile(async () => {
       // Restore the streak first: it decides whether a stale budget should be
       // restored optimistically or as a single throttled probe.
@@ -582,20 +587,14 @@ export class DiscogsRateLimiter implements DurableObject {
 
   private async executeRequest(req: RateLimiterRequest): Promise<RateLimiterResponse> {
     try {
-      const response = await fetch(req.url, {
-        method: req.method,
-        headers: req.headers,
-        body: req.body ?? undefined,
-      })
+      const viaRelay = await this.send(req, this.relay)
+      if (!this.relay || !isRelayLayerError(viaRelay.status, viaRelay.headers)) return viaRelay
 
-      const headers: Record<string, string> = {}
-      response.headers.forEach((value, key) => {
-        headers[key.toLowerCase()] = value
-      })
-
-      const body = await response.text()
-
-      return { status: response.status, headers, body }
+      // The relay itself failed (tunnel down, local proxy down, Access rejected
+      // us) rather than Discogs answering. Go direct for this one request so a
+      // dead relay degrades to the shared-IP behaviour instead of an outage.
+      console.warn(`[RL] Relay unavailable (HTTP ${viaRelay.status}), falling back to direct for ${new URL(req.url).pathname}`)
+      return await this.send(req, null)
     } catch (error) {
       console.error(`[RL] Fetch error for ${req.url}:`, error instanceof Error ? error.message : error)
       return {
@@ -606,6 +605,24 @@ export class DiscogsRateLimiter implements DurableObject {
         }),
       }
     }
+  }
+
+  /** One HTTP round trip to Discogs, through `relay` when given, direct otherwise. */
+  private async send(req: RateLimiterRequest, relay: RelayConfig | null): Promise<RateLimiterResponse> {
+    const response = await fetch(relayTarget(req.url, relay), {
+      method: req.method,
+      headers: relayHeaders(req.headers, relay),
+      body: req.body ?? undefined,
+    })
+
+    const headers: Record<string, string> = {}
+    response.headers.forEach((value, key) => {
+      headers[key.toLowerCase()] = value
+    })
+
+    const body = await response.text()
+
+    return { status: response.status, headers, body }
   }
 
   private async scheduleWindowReset(): Promise<void> {

--- a/src/rate-limiter/relay.ts
+++ b/src/rate-limiter/relay.ts
@@ -1,0 +1,90 @@
+// ABOUTME: Routes Discogs API calls through an optional self-hosted egress relay so
+// ABOUTME: they leave from an IP we own instead of Cloudflare's shared pool.
+
+/** The origin every Discogs API URL in this codebase starts with. */
+export const DISCOGS_ORIGIN = 'https://api.discogs.com'
+
+/**
+ * Where to send Discogs traffic instead of api.discogs.com, and how to get past
+ * the Cloudflare Access application that guards it.
+ *
+ * Why a relay exists: Discogs throttles by source IP (60 req/min authenticated),
+ * and a Worker's outbound fetch shares Cloudflare's egress IPs with every other
+ * Worker on the same colo. The relay is a Cloudflare Tunnel to a machine we
+ * control; requests exit from that machine's IP and the whole budget is ours.
+ * The relay host restores `Host` and `X-Forwarded-Host` to api.discogs.com, so
+ * OAuth 1.0a signatures computed against the real URL keep verifying.
+ */
+export interface RelayConfig {
+	/** Origin of the relay, no trailing slash, e.g. https://relay.discogs-mcp.com */
+	origin: string
+	/** Cloudflare Access service token, sent as CF-Access-Client-Id. */
+	clientId: string
+	/** Cloudflare Access service token, sent as CF-Access-Client-Secret. */
+	clientSecret: string
+}
+
+/** The subset of the Worker env the relay reads. All optional: unset means direct. */
+export interface RelayEnv {
+	DISCOGS_RELAY_ORIGIN?: string
+	RELAY_ACCESS_CLIENT_ID?: string
+	RELAY_ACCESS_CLIENT_SECRET?: string
+}
+
+/**
+ * Build the relay config from env, or null when the relay is off.
+ *
+ * All three values must be present. An origin without credentials would only
+ * ever produce Access 401s, so it is treated as "not configured" rather than
+ * half-configured; the log line at startup says which.
+ */
+export function relayConfigFrom(env: RelayEnv): RelayConfig | null {
+	const origin = env.DISCOGS_RELAY_ORIGIN?.trim().replace(/\/+$/, '')
+	const clientId = env.RELAY_ACCESS_CLIENT_ID?.trim()
+	const clientSecret = env.RELAY_ACCESS_CLIENT_SECRET?.trim()
+	if (!origin || !clientId || !clientSecret) return null
+	return { origin, clientId, clientSecret }
+}
+
+/**
+ * The URL to actually fetch. Only URLs on the Discogs origin are rewritten; the
+ * path and query are carried over untouched so the request Discogs eventually
+ * sees is byte-for-byte what was signed.
+ */
+export function relayTarget(url: string, relay: RelayConfig | null): string {
+	if (!relay || !url.startsWith(`${DISCOGS_ORIGIN}/`)) return url
+	return relay.origin + url.slice(DISCOGS_ORIGIN.length)
+}
+
+/** The request headers plus the Access service-token pair the relay requires. */
+export function relayHeaders(headers: Record<string, string>, relay: RelayConfig | null): Record<string, string> {
+	if (!relay) return headers
+	return {
+		...headers,
+		'CF-Access-Client-Id': relay.clientId,
+		'CF-Access-Client-Secret': relay.clientSecret,
+	}
+}
+
+/**
+ * Whether a response came from the relay path rather than from the Discogs API,
+ * in which case the caller should retry the request directly.
+ *
+ * The Discogs API answers in JSON and stamps every response with
+ * `x-discogs-*` headers, including its errors. Anything else with an error
+ * status is one of the layers in front of it: Cloudflare's 530 when the tunnel
+ * has no connector, cloudflared's 502 when the machine's local proxy is down,
+ * Access's HTML 401 when the service token is wrong, or an HTML 404 when the
+ * relay is misrouting. Falling back on those keeps a dead relay from becoming
+ * an outage; the worst case is the shared-IP behaviour we had before.
+ *
+ * A 429 is never a relay-layer error. Retrying a throttle on the shared IP would
+ * spend a second budget behind the limiter's back.
+ */
+export function isRelayLayerError(status: number, headers: Record<string, string>): boolean {
+	if (status < 400 || status === 429) return false
+	const fromDiscogs = Object.keys(headers).some((key) => key.toLowerCase().startsWith('x-discogs-'))
+	if (fromDiscogs) return false
+	const contentType = headers['content-type'] ?? headers['Content-Type'] ?? ''
+	return !contentType.toLowerCase().includes('application/json')
+}

--- a/src/types/env.ts
+++ b/src/types/env.ts
@@ -18,6 +18,17 @@ export interface Env {
   // Set via `wrangler secret put DEBUG_TOKEN --env production` with any random string.
   DEBUG_TOKEN?: string
 
+  // Optional egress relay for Discogs API calls (see src/rate-limiter/relay.ts).
+  // Discogs throttles per source IP and Workers share Cloudflare's egress IPs, so
+  // the hosted instance sends its calls through a Cloudflare Tunnel to a machine
+  // with an IP of its own. DISCOGS_RELAY_ORIGIN is a plain var (e.g.
+  // "https://relay.discogs-mcp.com"); the two RELAY_ACCESS_* values are the
+  // Cloudflare Access service token that guards it, set via `wrangler secret put`.
+  // Leave all three unset to call api.discogs.com directly (self-hosters, local dev).
+  DISCOGS_RELAY_ORIGIN?: string
+  RELAY_ACCESS_CLIENT_ID?: string
+  RELAY_ACCESS_CLIENT_SECRET?: string
+
   // JWT secret for legacy session-based handler (src/index.ts)
   JWT_SECRET: string
 

--- a/test/rate-limiter/relay.test.ts
+++ b/test/rate-limiter/relay.test.ts
@@ -1,0 +1,102 @@
+// ABOUTME: Unit tests for the egress-relay helpers the rate limiter uses to route
+// ABOUTME: Discogs calls through a self-hosted tunnel and to detect relay-layer failures.
+import { describe, it, expect } from 'vitest'
+
+import { relayConfigFrom, relayTarget, relayHeaders, isRelayLayerError, DISCOGS_ORIGIN } from '../../src/rate-limiter/relay'
+
+const relay = { origin: 'https://relay.example.com', clientId: 'id.access', clientSecret: 'shh' }
+
+describe('relayConfigFrom', () => {
+	it('is null when no relay origin is configured', () => {
+		expect(relayConfigFrom({})).toBeNull()
+		expect(relayConfigFrom({ DISCOGS_RELAY_ORIGIN: '' })).toBeNull()
+		expect(relayConfigFrom({ DISCOGS_RELAY_ORIGIN: '   ' })).toBeNull()
+	})
+
+	it('is null when the origin is set but the Access credentials are not', () => {
+		expect(relayConfigFrom({ DISCOGS_RELAY_ORIGIN: 'https://relay.example.com' })).toBeNull()
+		expect(relayConfigFrom({ DISCOGS_RELAY_ORIGIN: 'https://relay.example.com', RELAY_ACCESS_CLIENT_ID: 'id' })).toBeNull()
+	})
+
+	it('normalises a trailing slash off the origin', () => {
+		expect(
+			relayConfigFrom({
+				DISCOGS_RELAY_ORIGIN: 'https://relay.example.com/',
+				RELAY_ACCESS_CLIENT_ID: 'id.access',
+				RELAY_ACCESS_CLIENT_SECRET: 'shh',
+			}),
+		).toEqual(relay)
+	})
+})
+
+describe('relayTarget', () => {
+	it('rewrites the Discogs origin to the relay and keeps path and query intact', () => {
+		expect(relayTarget(`${DISCOGS_ORIGIN}/database/search?q=nirvana&per_page=1`, relay)).toBe(
+			'https://relay.example.com/database/search?q=nirvana&per_page=1',
+		)
+	})
+
+	it('leaves a URL alone when there is no relay', () => {
+		const url = `${DISCOGS_ORIGIN}/releases/1`
+		expect(relayTarget(url, null)).toBe(url)
+	})
+
+	it('leaves a non-Discogs URL alone even with a relay configured', () => {
+		expect(relayTarget('https://example.org/x', relay)).toBe('https://example.org/x')
+	})
+
+	it('does not rewrite a URL that merely mentions the Discogs host', () => {
+		expect(relayTarget('https://evil.example/https://api.discogs.com/x', relay)).toBe('https://evil.example/https://api.discogs.com/x')
+	})
+})
+
+describe('relayHeaders', () => {
+	it('adds the Access service-token headers without touching the rest', () => {
+		expect(relayHeaders({ Authorization: 'OAuth x', 'User-Agent': 'ua' }, relay)).toEqual({
+			Authorization: 'OAuth x',
+			'User-Agent': 'ua',
+			'CF-Access-Client-Id': 'id.access',
+			'CF-Access-Client-Secret': 'shh',
+		})
+	})
+
+	it('returns the headers unchanged when there is no relay', () => {
+		const headers = { Authorization: 'OAuth x' }
+		expect(relayHeaders(headers, null)).toEqual(headers)
+	})
+})
+
+describe('isRelayLayerError', () => {
+	it('flags a Cloudflare 530 with no Discogs headers (tunnel has no connector)', () => {
+		expect(isRelayLayerError(530, { 'content-type': 'text/html', 'cf-ray': 'abc' })).toBe(true)
+	})
+
+	it('flags an Access 401 (HTML, no Discogs headers)', () => {
+		expect(isRelayLayerError(401, { 'content-type': 'text/html; charset=utf-8' })).toBe(true)
+	})
+
+	it('flags a 502 from cloudflared when the local proxy is down', () => {
+		expect(isRelayLayerError(502, { 'content-type': 'text/plain' })).toBe(true)
+	})
+
+	it('flags an HTML 404 that is not the Discogs API answering', () => {
+		expect(isRelayLayerError(404, { 'content-type': 'text/html' })).toBe(true)
+	})
+
+	it('does not flag a Discogs 401 (JSON) — that is a real auth failure', () => {
+		expect(isRelayLayerError(401, { 'content-type': 'application/json' })).toBe(false)
+	})
+
+	it('does not flag a Discogs 404 that carries the API rate-limit headers', () => {
+		expect(isRelayLayerError(404, { 'x-discogs-ratelimit': '60', 'content-type': 'text/html' })).toBe(false)
+	})
+
+	it('never flags a 429, so a throttle is surfaced rather than retried on the shared IP', () => {
+		expect(isRelayLayerError(429, { 'content-type': 'text/html' })).toBe(false)
+	})
+
+	it('never flags a success', () => {
+		expect(isRelayLayerError(200, {})).toBe(false)
+		expect(isRelayLayerError(204, {})).toBe(false)
+	})
+})

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -20,6 +20,14 @@ crons = ["23 1,7,13,19 * * *"]
 # Empty = no allowlist (open; default for local dev and self-hosters).
 [vars]
 ALLOWED_DISCOGS_USER_ID = ""
+# Optional egress relay for Discogs API calls. Discogs throttles per source IP
+# and Workers share Cloudflare's egress IPs, so the hosted instance routes its
+# calls through a Cloudflare Tunnel to a machine with an IP of its own (see
+# src/rate-limiter/relay.ts). Empty = call api.discogs.com directly, which is
+# the right default for self-hosters and local dev. When set, the two Access
+# service-token secrets RELAY_ACCESS_CLIENT_ID / RELAY_ACCESS_CLIENT_SECRET
+# must be set too, or the relay is treated as off.
+DISCOGS_RELAY_ORIGIN = ""
 
 # Durable Object for coordinated Discogs API rate limiting
 [durable_objects]
@@ -56,6 +64,9 @@ name = "discogs-mcp-prod"
 # Discogs API rate limits are too tight to share, so anyone else must self-host.
 [env.production.vars]
 ALLOWED_DISCOGS_USER_ID = "2579319,2316828"
+# Discogs traffic leaves via the maintainer's Mac mini (Cloudflare Tunnel +
+# local Caddy), guarded by Cloudflare Access; secrets carry the service token.
+DISCOGS_RELAY_ORIGIN = "https://relay.discogs-mcp.com"
 
 [env.production.durable_objects]
 bindings = [
@@ -78,3 +89,4 @@ id = "35c396a7d0924dd8a5527334cd4538d3"
 # - DISCOGS_CONSUMER_KEY
 # - DISCOGS_CONSUMER_SECRET
 # - JWT_SECRET
+# - RELAY_ACCESS_CLIENT_ID / RELAY_ACCESS_CLIENT_SECRET (only with DISCOGS_RELAY_ORIGIN)


### PR DESCRIPTION
## Why

Discogs throttles by source IP (60/min authenticated), and the rate-limiter DO's outbound fetch leaves from Cloudflare's shared egress pool. Every other Worker on the same colo that talks to Discogs draws on the same budget, which is why the sync's first request after six idle hours arrives with `x-discogs-ratelimit-remaining: 6` (#52). Nothing in #48–#50 could make a request succeed; it only reported the throttle more honestly.

There is no dedicated egress IP for Workers, and the Cloudflare products that offer one are Enterprise add-ons. So: a Cloudflare Tunnel to a machine we control (the maintainer's Mac mini), guarded by a Cloudflare Access service token, with a local Caddy that forwards to `api.discogs.com`. Requests exit from that machine's IP and the whole 60/min is ours.

## What changes

- `src/rate-limiter/relay.ts` (new): `relayConfigFrom(env)` reads `DISCOGS_RELAY_ORIGIN` + `RELAY_ACCESS_CLIENT_ID/SECRET` (all three or nothing); `relayTarget` rewrites only URLs on the Discogs origin, path and query untouched, so what Discogs eventually sees is byte-for-byte what was signed; `relayHeaders` adds the two `CF-Access-*` headers.
- DO constructor now takes `env`; `executeRequest` sends via the relay and, when the reply is a relay-layer failure rather than Discogs answering, retries that one request directly and logs `[RL] Relay unavailable (HTTP n), falling back to direct for /path`. `isRelayLayerError` = error status with neither an `x-discogs-*` header nor a JSON body: Cloudflare's 530 (no connector), cloudflared's 502 (local proxy down), Access's HTML 401, a misrouted HTML 404. Never a 429, so a throttle is surfaced rather than retried on the shared IP. A machine that's switched off degrades to today's behaviour, never an outage.
- Empty `DISCOGS_RELAY_ORIGIN` at the top level of `wrangler.toml` keeps self-hosters and local dev on the direct path. `[env.production.vars]` sets `https://relay.discogs-mcp.com`; the two secrets are already uploaded to `discogs-mcp-prod`.
- README: an optional "route Discogs calls through your own IP" section for self-hosters, including the `X-Forwarded-Host` gotcha below.
- The two bare `/oauth/identity` fetches in the OAuth handshake stay direct; once per login.

## The gotcha, for the record

cloudflared alone (`service: https://api.discogs.com` + `httpHostHeader`) worked for `/users/...` and `/releases/...` and failed for `/database/search`, `/oauth/identity` and `/`, returning Discogs's HTML 404 page. When cloudflared rewrites `Host` it also adds `X-Forwarded-Host: <relay hostname>` and overwrites a client-supplied value; Discogs honours that header on those routes. Caddy on the relay host sets both headers to `api.discogs.com`.

## Verification

- 17 new unit tests in `test/rate-limiter/relay.test.ts`; full suite 30 files / 321 tests green; lint clean; `wrangler deploy --dry-run` shows the new var.
- Relay verified end to end from a laptop before this change: cloudflared + Caddy through the tunnel returned Discogs JSON for `/`, `/database/search`, `/oauth/identity`, `/users/.../wants`, `/users/.../collection/...`, `/releases/...`, `/masters/.../versions`, with `x-discogs-ratelimit: 60` counting down from 59 on the connector machine's IP. Access: no headers → 401, wrong secret → 401. No connector → 530.
- The Mac mini connector is live: tunnel `healthy`, four QUIC connections. Same checks pass through it.

## After merge

CI deploys prod. Then: `/debug/budget` and the next cron at :23 UTC should log the first request of a cold run with `remaining: 59` rather than single digits, and no `Relay unavailable` lines. Rollback is a redeploy with `DISCOGS_RELAY_ORIGIN = ""`, or just stopping the mini's connector and letting the fallback do its thing. Note the DO keeps running the old script version until evicted; check the log's `$workers.scriptVersion.id` before trusting a post-deploy test.

Refs #52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
