### PR TITLE
feat(rate-limit): report egress relay state in ping and server_info

### DIFF
--- a/src/mcp/tools/public.ts
+++ b/src/mcp/tools/public.ts
@@ -7,6 +7,7 @@ import { z } from 'zod'
 import type { Env } from '../../types/env.js'
 import type { SessionContext } from '../server.js'
 import { buildNextSteps } from '../../utils/breadcrumb.js'
+import { describeRelayStatus, type RelayStatus } from '../../rate-limiter/relay.js'
 
 /**
  * Generate authentication URL with connection ID if available
@@ -14,6 +15,23 @@ import { buildNextSteps } from '../../utils/breadcrumb.js'
 function getAuthUrl(connectionId?: string): string {
 	const baseUrl = 'https://discogs-mcp.com'
 	return connectionId ? `${baseUrl}/login?connection_id=${connectionId}` : `${baseUrl}/login`
+}
+
+/**
+ * Ask the rate limiter how Discogs traffic is leaving right now. The relay
+ * falls back to direct calls without any change to tool results, so this line
+ * in ping / server_info is how a user learns the relay host is down. Never
+ * throws: a limiter that can't be reached is reported as such.
+ */
+async function relayStatusLine(env: Env): Promise<string> {
+	try {
+		const stub = env.RATE_LIMITER.get(env.RATE_LIMITER.idFromName('discogs-rate-limiter'))
+		const res = await stub.fetch(new Request('http://do/state'))
+		const state = (await res.json()) as { relay?: RelayStatus }
+		return describeRelayStatus(state.relay ?? null, Date.now())
+	} catch {
+		return describeRelayStatus(null, Date.now())
+	}
 }
 
 /**
@@ -28,6 +46,7 @@ export function registerPublicTools(server: McpServer, env: Env, getSessionConte
 			message: z.string().optional().default('Hello from Discogs MCP!').describe('Message to echo back'),
 		},
 		async ({ message }) => {
+			const egress = await relayStatusLine(env)
 			const nextSteps = buildNextSteps([
 				{ tool: 'server_info', args: '', hint: 'see server version and feature list' },
 				{ tool: 'auth_status', args: '', hint: 'check whether you are authenticated' },
@@ -36,7 +55,7 @@ export function registerPublicTools(server: McpServer, env: Env, getSessionConte
 				content: [
 					{
 						type: 'text',
-						text: `Pong! You said: ${message}${nextSteps}`,
+						text: `Pong! You said: ${message}\n${egress}${nextSteps}`,
 					},
 				],
 			}
@@ -47,6 +66,7 @@ export function registerPublicTools(server: McpServer, env: Env, getSessionConte
 	server.tool('server_info', 'Get information about the Discogs MCP server', {}, async () => {
 		const { connectionId } = await getSessionContext()
 		const authUrl = getAuthUrl(connectionId)
+		const egress = await relayStatusLine(env)
 
 		const nextSteps = buildNextSteps([
 			{ tool: 'auth_status', args: '', hint: 'check whether the current session is authenticated' },
@@ -57,7 +77,7 @@ export function registerPublicTools(server: McpServer, env: Env, getSessionConte
 			content: [
 				{
 					type: 'text',
-					text: `Discogs MCP Server v3.1.0\n\nStatus: Running\nProtocol: MCP 2024-11-05\nFeatures:\n- Resources: Collection, Releases, Search\n- Authentication: OAuth 1.0a\n- Rate Limiting: Enabled\n\nTo get started, authenticate at ${authUrl}${nextSteps}`,
+					text: `Discogs MCP Server v3.1.0\n\nStatus: Running\nProtocol: MCP 2024-11-05\nFeatures:\n- Resources: Collection, Releases, Search\n- Authentication: OAuth 1.0a\n- Rate Limiting: Enabled\n- ${egress}\n\nTo get started, authenticate at ${authUrl}${nextSteps}`,
 				},
 			],
 		}

--- a/src/rate-limiter/durable-object.ts
+++ b/src/rate-limiter/durable-object.ts
@@ -1,6 +1,6 @@
 // src/rate-limiter/durable-object.ts
 import type { RateLimiterRequest, RateLimiterResponse, BudgetState, RequestPriority } from './types'
-import { relayConfigFrom, relayTarget, relayHeaders, isRelayLayerError, type RelayConfig, type RelayEnv } from './relay'
+import { relayConfigFrom, relayTarget, relayHeaders, isRelayLayerError, type RelayConfig, type RelayEnv, type RelayStatus } from './relay'
 
 const MAX_QUEUE_DEPTH = 20
 const QUEUE_TIMEOUT_MS = 90_000
@@ -231,12 +231,19 @@ export class DiscogsRateLimiter implements DurableObject {
   private trippedUntil: number | null = null
   /** Egress relay to send Discogs calls through; null = straight to api.discogs.com. */
   private relay: RelayConfig | null
+  /** Times a request fell back from the relay to a direct call. Persisted. */
+  private relayFallbacks = 0
+  /** Wall-clock ms of the most recent such fallback; null = none. Persisted. */
+  private lastRelayFallbackAt: number | null = null
 
   constructor(state: DurableObjectState, env: RelayEnv) {
     this.state = state
     this.relay = relayConfigFrom(env)
     console.log(this.relay ? `[RL] Egress relay enabled: ${this.relay.origin}` : '[RL] Egress relay off, calling api.discogs.com directly')
     state.blockConcurrencyWhile(async () => {
+      this.relayFallbacks = (await state.storage.get<number>('relayFallbacks')) ?? 0
+      this.lastRelayFallbackAt = (await state.storage.get<number>('lastRelayFallbackAt')) ?? null
+
       // Restore the streak first: it decides whether a stale budget should be
       // restored optimistically or as a single throttled probe.
       const storedStreak = await state.storage.get<number>('consecutive429s')
@@ -318,6 +325,7 @@ export class DiscogsRateLimiter implements DurableObject {
               ? cooldownRetryAfterSecs(this.trippedUntil, now)
               : 0,
           },
+          relay: this.relayStatus(),
           serverTime: now,
         }),
         { status: 200, headers: { 'Content-Type': 'application/json' } },
@@ -594,6 +602,7 @@ export class DiscogsRateLimiter implements DurableObject {
       // us) rather than Discogs answering. Go direct for this one request so a
       // dead relay degrades to the shared-IP behaviour instead of an outage.
       console.warn(`[RL] Relay unavailable (HTTP ${viaRelay.status}), falling back to direct for ${new URL(req.url).pathname}`)
+      await this.recordRelayFallback()
       return await this.send(req, null)
     } catch (error) {
       console.error(`[RL] Fetch error for ${req.url}:`, error instanceof Error ? error.message : error)
@@ -605,6 +614,24 @@ export class DiscogsRateLimiter implements DurableObject {
         }),
       }
     }
+  }
+
+  /** What `ping` / `server_info` / `/debug/budget` report about the relay. */
+  private relayStatus(): RelayStatus {
+    return {
+      enabled: this.relay !== null,
+      origin: this.relay?.origin ?? null,
+      lastFallbackAt: this.lastRelayFallbackAt,
+      fallbacks: this.relayFallbacks,
+    }
+  }
+
+  /** Count a fallback and persist it, so a restart doesn't erase the evidence. */
+  private async recordRelayFallback(): Promise<void> {
+    this.relayFallbacks += 1
+    this.lastRelayFallbackAt = Date.now()
+    await this.state.storage.put('relayFallbacks', this.relayFallbacks)
+    await this.state.storage.put('lastRelayFallbackAt', this.lastRelayFallbackAt)
   }
 
   /** One HTTP round trip to Discogs, through `relay` when given, direct otherwise. */

--- a/src/rate-limiter/relay.ts
+++ b/src/rate-limiter/relay.ts
@@ -88,3 +88,40 @@ export function isRelayLayerError(status: number, headers: Record<string, string
 	const contentType = headers['content-type'] ?? headers['Content-Type'] ?? ''
 	return !contentType.toLowerCase().includes('application/json')
 }
+
+/** What the rate limiter reports about the relay through its `/state` endpoint. */
+export interface RelayStatus {
+	enabled: boolean
+	/** Relay origin when enabled, else null. */
+	origin: string | null
+	/** Wall-clock ms of the most recent fallback to a direct call; null = none recorded. */
+	lastFallbackAt: number | null
+	/** Fallbacks recorded so far. Persisted by the DO, so it survives restarts. */
+	fallbacks: number
+}
+
+/** "just now", "4 min ago", "3 h ago", "2 d ago" — coarse on purpose, this is a status line. */
+export function describeAge(sinceMs: number, now: number): string {
+	const s = Math.max(0, Math.round((now - sinceMs) / 1000))
+	if (s < 60) return 'just now'
+	const m = Math.round(s / 60)
+	if (m < 60) return `${m} min ago`
+	const h = Math.round(m / 60)
+	if (h < 24) return `${h} h ago`
+	return `${Math.round(h / 24)} d ago`
+}
+
+/**
+ * One human-readable line for `ping` / `server_info` saying how Discogs traffic
+ * is leaving and whether the relay has failed lately. The relay falls back to
+ * direct calls silently as far as tool results go, so this is where a user
+ * finds out that the relay host is down.
+ */
+export function describeRelayStatus(status: RelayStatus | null, now: number): string {
+	if (!status) return 'Discogs egress: status unavailable (rate limiter did not answer)'
+	if (!status.enabled) return 'Discogs egress: direct from Cloudflare (no relay configured)'
+	const host = status.origin ? new URL(status.origin).host : 'relay'
+	if (status.fallbacks === 0 || status.lastFallbackAt === null) return `Discogs egress: via relay ${host}, no fallbacks recorded`
+	const times = status.fallbacks === 1 ? 'once' : `${status.fallbacks} times`
+	return `Discogs egress: via relay ${host}; fell back to direct ${times}, last ${describeAge(status.lastFallbackAt, now)} — the relay host may be down`
+}

--- a/test/rate-limiter/relay.test.ts
+++ b/test/rate-limiter/relay.test.ts
@@ -2,7 +2,15 @@
 // ABOUTME: Discogs calls through a self-hosted tunnel and to detect relay-layer failures.
 import { describe, it, expect } from 'vitest'
 
-import { relayConfigFrom, relayTarget, relayHeaders, isRelayLayerError, DISCOGS_ORIGIN } from '../../src/rate-limiter/relay'
+import {
+	relayConfigFrom,
+	relayTarget,
+	relayHeaders,
+	isRelayLayerError,
+	describeAge,
+	describeRelayStatus,
+	DISCOGS_ORIGIN,
+} from '../../src/rate-limiter/relay'
 
 const relay = { origin: 'https://relay.example.com', clientId: 'id.access', clientSecret: 'shh' }
 
@@ -98,5 +106,51 @@ describe('isRelayLayerError', () => {
 	it('never flags a success', () => {
 		expect(isRelayLayerError(200, {})).toBe(false)
 		expect(isRelayLayerError(204, {})).toBe(false)
+	})
+})
+
+describe('describeAge', () => {
+	it('rounds to the coarsest sensible unit', () => {
+		const now = 1_000_000_000
+		expect(describeAge(now - 20_000, now)).toBe('just now')
+		expect(describeAge(now - 4 * 60_000, now)).toBe('4 min ago')
+		expect(describeAge(now - 3 * 3_600_000, now)).toBe('3 h ago')
+		expect(describeAge(now - 2 * 86_400_000, now)).toBe('2 d ago')
+	})
+})
+
+describe('describeRelayStatus', () => {
+	const now = 1_000_000_000
+
+	it('says so when the limiter could not be asked', () => {
+		expect(describeRelayStatus(null, now)).toContain('status unavailable')
+	})
+
+	it('reports direct egress when no relay is configured', () => {
+		expect(describeRelayStatus({ enabled: false, origin: null, lastFallbackAt: null, fallbacks: 0 }, now)).toBe(
+			'Discogs egress: direct from Cloudflare (no relay configured)',
+		)
+	})
+
+	it('names the relay host and a clean record', () => {
+		expect(describeRelayStatus({ enabled: true, origin: 'https://relay.example.com', lastFallbackAt: null, fallbacks: 0 }, now)).toBe(
+			'Discogs egress: via relay relay.example.com, no fallbacks recorded',
+		)
+	})
+
+	it('surfaces fallbacks with a count and an age, and points at the relay host', () => {
+		const line = describeRelayStatus(
+			{ enabled: true, origin: 'https://relay.example.com', lastFallbackAt: now - 4 * 60_000, fallbacks: 3 },
+			now,
+		)
+		expect(line).toBe(
+			'Discogs egress: via relay relay.example.com; fell back to direct 3 times, last 4 min ago — the relay host may be down',
+		)
+	})
+
+	it('says "once" for a single fallback', () => {
+		expect(
+			describeRelayStatus({ enabled: true, origin: 'https://relay.example.com', lastFallbackAt: now - 1000, fallbacks: 1 }, now),
+		).toContain('fell back to direct once, last just now')
 	})
 })


### PR DESCRIPTION
Follow-up to #53. The relay falls back to direct Discogs calls when the relay host is unreachable, which keeps the server up but gives the user no way to tell which mode they're in short of reading Workers logs.

- The rate-limiter DO counts fallbacks and remembers the last one (persisted, so a restart doesn't erase the evidence) and reports them under `relay` in `/state`, so `/debug/budget` shows it too.
- `describeRelayStatus` renders one line, e.g. `Discogs egress: via relay relay.discogs-mcp.com, no fallbacks recorded` or `...; fell back to direct 3 times, last 4 min ago — the relay host may be down`, or `direct from Cloudflare (no relay configured)`.
- `ping` and `server_info` include that line. Asking the limiter never throws; if it can't be reached the line says `status unavailable`.

Tests: 6 new (30 files / 327 total green), lint clean, dry-run build fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
